### PR TITLE
More MacOS fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ install clang-16.  Using a more recent version of clang such as clang-19 will
 not work because it limits the use of bit-precise integers to 128 bits.
 
     brew install llvm@16
+    brew install cmake
     echo 'export PATH="/opt/homebrew/opt/llvm@16/bin:$PATH"' >> ~/.zshrc
     sudo bash -c "sh <(curl -fsSL https://opam.ocaml.org/install.sh)"
     opam update

--- a/bin/asl2c.py
+++ b/bin/asl2c.py
@@ -395,6 +395,7 @@ def compile_and_link(use_cxx, c_files, exe_file, include_directory, c_flags, ld_
         #     exit(1)
         # cc.append(f'-I{ac_types_dir}/include')
         cc.append('-lstdc++')
+        cc.append('-std=c++17')
     else:
         cc.append('-std=c2x')
     cc_cmd = cc + [

--- a/runtime/test/Makefile
+++ b/runtime/test/Makefile
@@ -19,6 +19,7 @@ default: $(TESTS_BIN)
 CXX = g++
 CPPFLAGS = -I$(GTEST_DIR)/googletest/include -I../include
 CXXFLAGS = -g -Wall -Werror
+CXXFLAGS += -std=c++17
 
 CC_FILES = integer_test.cc bits_test.cc ram_test.cc
 OBJ_FILES = $(CC_FILES:%.cc=$(OBJ_DIR)/%.o)


### PR DESCRIPTION
These commits fix more of the issues using ASLi on MacOS

- C++ backends not working because they need to specify a C++ standard version
- Installing cmake  because it is needed by google test
- Upgrading google test submodule because cmake was warning about using old make files

This does not fix all the issues yet

- Having trouble using lit/filecheck to check an error message (because it is on stderr)
- Hardcoded clang version in the demo
- The c23 backend does not work on MacOS because the maximum size value is 128 bits.  (Oddly, this is not an issue on other platforms)
- Issue with the %decolor substitution used with lit

These affect our ability to run tests