### PR TITLE
Fix almost all osx issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,13 @@ runtime_test:
 lit_test: build
 	env PATH="`pwd`/tests/scripts:${PATH}" ${LIT} tests/lit -v
 
-BACKENDS = interpreter c23 ac fallback
+WIDE_BITINT_SUPPORTED := `$(MAKE) -C runtime/test wide_bitint_supported`
+
+ifeq (1, $(WIDE_BITINT_SUPPORTED))
+BACKENDS := interpreter c23 ac fallback
+else
+BACKENDS := interpreter ac fallback
+endif
 
 test_backends: ${addprefix test_backend_, ${BACKENDS}}
 

--- a/bin/asli.ml
+++ b/bin/asli.ml
@@ -32,7 +32,9 @@ let opt_show_banner = ref true
 let history_file = "asl_history"
 
 let cleanup_and_exit (code : int) : 'a =
-  LNoise.history_save ~filename:history_file |> ignore;
+  if not !opt_batchmode then begin
+    LNoise.history_save ~filename:history_file |> ignore
+  end;
   exit code
 
 (* on error, optionally exit if in batchmode *)

--- a/libASL/runtime_c23.ml
+++ b/libASL/runtime_c23.ml
@@ -75,6 +75,10 @@ module Runtime : RT.RuntimeLib = struct
       PP.fprintf fmt "((%a)0x%swb)"
         ty_sint n
         (Z.format "%x" x)
+    else if Z.equal x (min_sintN n) then
+      PP.fprintf fmt "((%a)(-0x%swb) - 1wb)"
+        ty_sint n
+        (Z.format "%x" (Z.sub Z.minus_one x))
     else (* negative values *)
       PP.fprintf fmt "((%a)-0x%swb)"
         ty_sint n

--- a/runtime/include/asl/runtime.h
+++ b/runtime/include/asl/runtime.h
@@ -12,6 +12,7 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <limits.h>
 
 // The following types are used in the foreign function interface
 typedef __int128 ASL_int_t;
@@ -20,8 +21,12 @@ typedef uint16_t ASL_bits16_t;
 typedef uint32_t ASL_bits32_t;
 typedef uint64_t ASL_bits64_t;
 typedef unsigned __int128 ASL_bits128_t;
+#if BITINT_MAXWIDTH >= 256
 typedef unsigned _BitInt(256) ASL_bits256_t;
+#endif
+#if BITINT_MAXWIDTH >= 256
 typedef unsigned _BitInt(512) ASL_bits512_t;
+#endif
 
 #define ASL_cast_bits_512_64(x) ((ASL_bits64_t)(x))
 #define ASL_cast_bits_256_64(x) ((ASL_bits64_t)(x))

--- a/runtime/test/.gitignore
+++ b/runtime/test/.gitignore
@@ -1,0 +1,1 @@
+bitint_maxwidth

--- a/runtime/test/Makefile
+++ b/runtime/test/Makefile
@@ -45,3 +45,10 @@ $(TESTS_BIN): gtest $(OBJ_FILES)
 	$(info CXX     $(@F))
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(OBJ_FILES) -L$(BUILD_DIR)/.. -lASL -L$(GTEST_BUILD_DIR)/lib -lgtest -lgtest_main -o $@
 	$(TESTS_BIN) --gtest_brief
+
+# Test for whether C compiler supports _BitInt(129) or wider
+.PHONY: wide_bitint_supported
+wide_bitint_supported: bitint_maxwidth.c
+	@ $(CC) -std=c2x $< -o bitint_maxwidth
+	@ test `./bitint_maxwidth` -le 128; echo $$?
+	@ $(RM) bitint_maxwidth

--- a/runtime/test/bitint_maxwidth.c
+++ b/runtime/test/bitint_maxwidth.c
@@ -1,0 +1,7 @@
+#include <limits.h>
+#include <stdio.h>
+
+int main() {
+  printf("%d\n", BITINT_MAXWIDTH);
+  return 0;
+}

--- a/tests/test_cases_backend.ml
+++ b/tests/test_cases_backend.ml
@@ -12,7 +12,7 @@ let expr : test_case list =
   [
     ( "bitslice lowd (> 64b)",
       [ Backend_C; Backend_Verilog ],
-      "func F(x : bits(129)) => bits(65) begin return x[4 +: 65]; end" );
+      "func F(x : bits(127)) => bits(65) begin return x[4 +: 65]; end" );
 
     ( "literal int",
       [ Backend_C; Backend_Verilog ],


### PR DESCRIPTION
Remaining issues

- generating an ELF file on OSX is harder because of a different as and ld implementation and because OSX does not natively use ELF files
- three lit/filecheck tests use not and |& to check that error cases generate the correct error message. Unfortunately, this does not work (and the error message is hard to diagnose).