### PR TITLE
GitHub workflow: fix caching

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,7 +10,7 @@ env:
   OPAMROOT: ${{ github.workspace }}/.opam
 
 jobs:
-  test:
+  setup:
     runs-on: ubuntu-latest
 
     steps:
@@ -52,6 +52,10 @@ jobs:
           opam env
           opam install . --deps-only --with-test --with-doc --yes
 
+  test:
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
       - name: Build
         run: |
           eval $(opam env)


### PR DESCRIPTION
This splits the workflow into two jobs so that, even if the test fails, we still cache the .opam directory