### PR TITLE
Use available_features.append

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -24,7 +24,7 @@ config.available_features = [backend]
 
 proc = subprocess.run(["make", f"-C{asl_path}/runtime/test", "wide_bitint_supported"], capture_output=True, encoding='latin_1')
 if proc.returncode == 0 and "1" in proc.stdout:
-    config.available_features.add("wide_bitint")
+    config.available_features.append("wide_bitint")
 
 config.substitutions.append(('%asli', asli_bin_path))
 config.substitutions.append(('%aslrun', f"{asl2c_path} --backend={backend} -O0 --run"))


### PR DESCRIPTION
Since available_features is a list.

Fixes the error:
```
  File "/disk1/asl/asl-interpreter-il/tests/lit.cfg", line 27, in <module>
    config.available_features.add("wide_bitint")
AttributeError: 'list' object has no attribute 'add'
```