### PR TITLE
New transform :xform_hoist-lets

### DIFF
--- a/bin/asl2c.py
+++ b/bin/asl2c.py
@@ -121,6 +121,15 @@ base_script = """
 // todo: explain why this needs to be repeated
 :xform_bittuples
 
+// Lift let-expressions as high as possible out of an expression
+// e.g., F(G(let t = 1 in H(t))) -> let t = 1 in F(G(H(t)))
+// (This makes later transformations work better if, for example,
+// they should match against "G(H(..))")
+//
+// Note that source code is not expected to contain let-expressions.
+// They only exist to make some transformations easier to write.
+:xform_hoist_lets
+
 // Convert bitslice operations like "x[i] = '1';" to a combination
 // of AND/OR and shift operations like "x = x OR (1 << i);"
 // This works better after constant propagation/monomorphization.

--- a/libASL/asl_utils.ml
+++ b/libASL/asl_utils.ml
@@ -1086,6 +1086,34 @@ let mk_cvt_int_bits (n : AST.expr) (x : AST.expr) : AST.expr =
   Expr_TApply (cvt_int_bits, [ n ], [ x; n ], NoThrow)
 
 (****************************************************************)
+(** {2 Let expressions and statements}                          *)
+(****************************************************************)
+
+(** Construct nested let-expressions from a list of bindings
+ *
+ *     mk_let_exprs [(x, tx, ex); (y, ty, ey)] e
+ *   =
+ *     let x:tx = ex in (let y:ty = ey in e)
+ *)
+let rec mk_let_exprs (bindings : (Ident.t * AST.ty * AST.expr) list) (e : AST.expr) : AST.expr =
+  ( match bindings with
+  | [] -> e
+  | ((v, ty, e') :: bs) -> AST.Expr_Let(v, ty, e', mk_let_exprs bs e)
+  )
+
+(** Construct assignments from a list of bindings
+ *
+ *     mk_assigns loc [(x, tx, ex); (y, ty, ey)]
+ *   =
+ *     let x : tx = ex;
+ *     let y : ty = ey;
+ *)
+let mk_assigns (loc : Loc.t) (bindings : (Ident.t * AST.ty * AST.expr) list) : AST.stmt list =
+  List.map (fun (v, ty, e) ->
+    AST.Stmt_ConstDecl (DeclItem_Var (v, Some ty), e, loc))
+    bindings
+
+(****************************************************************)
 (** {2 Safe expressions}                                        *)
 (****************************************************************)
 

--- a/libASL/asl_utils.mli
+++ b/libASL/asl_utils.mli
@@ -374,6 +374,27 @@ val mk_ors : AST.expr list -> AST.expr
 val mk_cvt_int_bits : AST.expr -> AST.expr -> AST.expr
 
 (****************************************************************)
+(** {2 Let expressions}                                         *)
+(****************************************************************)
+
+(** Construct nested let-expressions from a list of bindings
+ *
+ *     mk_let_exprs [(x, tx, ex); (y, ty, ey)] e
+ *   =
+ *     let x:tx = ex in (let y:ty = ey in e)
+ *)
+val mk_let_exprs : (Ident.t * AST.ty * AST.expr) list -> AST.expr -> AST.expr
+
+(** Construct assignments from a list of bindings
+ *
+ *     mk_assigns loc [(x, tx, ex); (y, ty, ey)]
+ *   =
+ *     let x : tx = ex;
+ *     let y : ty = ey;
+ *)
+val mk_assigns : Loc.t -> (Ident.t * AST.ty * AST.expr) list -> AST.stmt list
+
+(****************************************************************)
 (** {2 Safe expressions}                                        *)
 (****************************************************************)
 

--- a/libASL/dune
+++ b/libASL/dune
@@ -65,6 +65,7 @@
    xform_constprop
    xform_desugar
    xform_getset
+   xform_hoist_lets
    xform_int_bitslices
    xform_lower
    xform_mono

--- a/libASL/xform_hoist_lets.ml
+++ b/libASL/xform_hoist_lets.ml
@@ -1,0 +1,177 @@
+(****************************************************************
+ * ASL let-hoisting transform
+ *
+ * Lifts let-bindings as high as possible out of expressions.
+ *
+ * The main restrictions on lifting let-bindings are
+ *
+ * - not lifting the let-binding out of a while guard condition
+ *   in case the let-binding depends on a variable that is modified
+ *   by the while loop or has side-effects.
+ *
+ * - not lifting the let-binding out of elsif conditions, case-alternative
+ *   guards or catcher-guards in case the let-binding is evaluated
+ *   earlier than other conditions/guards in the statement.
+ *
+ * - not lifting the let-binding out of the body of an if-expression
+ *   or out of the second argument of && or || in case the let-binding
+ *   contains a side-effect or can throw an exception or can
+ *   trigger a runtime error.
+ *
+ * When these restrictions do not limit how high a binding can be lifted,
+ * they normally turn into assignments prior to the statement that
+ * contains the expression.
+ *
+ * Copyright (C) 2025-2025 Intel Corporation
+ * SPDX-Licence-Identifier: BSD-3-Clause
+ ****************************************************************)
+
+module AST = Asl_ast
+open Asl_visitor
+open Builtin_idents
+
+type binding = (Ident.t * AST.ty * AST.expr)
+
+class hoist_lets (ds : AST.declaration list option) = object (self)
+    inherit nopAslVisitor
+
+    val mutable bindings : binding list = []
+
+    (* Hoist let-expressions out of an expression *)
+    method hoist_lets_out_of_expression (x : AST.expr) : (binding list * AST.expr) =
+      let old = bindings in
+      bindings <- [];
+      let x' = visit_expr (self :> aslVisitor) x in
+      let binds = bindings in
+      bindings <- old;
+      (binds, x')
+
+    (* Hoist let-expressions to the top of expression *)
+    method hoist_lets_to_expression_top (x : AST.expr) : AST.expr =
+      let (lets, x') = self#hoist_lets_out_of_expression x in
+      Asl_utils.mk_let_exprs lets x'
+
+    method! vexpr x =
+      ( match x with
+      | Expr_Let (x, ty, e1, e2) ->
+          let e1' = visit_expr (self :> aslVisitor) e1 in
+          let e2' = visit_expr (self :> aslVisitor) e2 in
+          bindings <- (x, ty, e1') :: bindings;
+          Visitor.ChangeTo e2'
+      | Expr_TApply (f, [], [a; b], NoThrow) when Ident.in_list f [and_bool; or_bool; implies_bool] ->
+          let a' = visit_expr (self :> aslVisitor) a in
+          let b' = self#hoist_lets_to_expression_top b in
+          if a == a' && b == b' then (
+            Visitor.SkipChildren
+          ) else (
+            Visitor.ChangeTo (Expr_TApply (f, [], [a'; b'], NoThrow))
+          )
+      | Expr_If (c, t, els, e) ->
+          let c' = visit_expr (self :> aslVisitor) c in
+          let t' = self#hoist_lets_to_expression_top t in
+          let els' = Visitor.mapNoCopy (visit_e_elsif (self :> aslVisitor)) els in
+          let e' = self#hoist_lets_to_expression_top e in
+          if c == c' && t == t' && els == els' && e == e' then (
+            Visitor.SkipChildren
+          ) else (
+            Visitor.ChangeTo (Expr_If (c', t', els', e'))
+          )
+      | _ ->
+          Visitor.DoChildren
+      )
+
+    method! vstmt x =
+      assert (Utils.is_empty bindings);
+      ( match x with
+      | Stmt_If (c, t, els, (e, el), loc) ->
+          let (lets, c') = self#hoist_lets_out_of_expression c in
+          let t' = visit_stmts (self :> aslVisitor) t in
+          let els' = Visitor.mapNoCopy (visit_s_elsif (self :> aslVisitor)) els in
+          let e' = visit_stmts (self :> aslVisitor) e in
+          if Utils.is_empty lets && c == c' && t == t' && els == els' && e == e' then (
+            Visitor.SkipChildren
+          ) else (
+            Visitor.ChangeTo (Asl_utils.mk_assigns loc lets @ [Stmt_If (c', t', els', (e', el), loc)])
+          )
+      | Stmt_While (c, b, loc) ->
+          let c' = self#hoist_lets_to_expression_top c in
+          let b' = visit_stmts (self :> aslVisitor) b in
+          if c == c' && b == b' then (
+            Visitor.SkipChildren
+          ) else (
+            Visitor.ChangeTo [Stmt_While (c', b', loc)]
+          )
+      | Stmt_Repeat (b, c, pos, loc) ->
+          let b' = visit_stmts (self :> aslVisitor) b in
+          let (lets, c') = self#hoist_lets_out_of_expression c in
+          if Utils.is_empty lets && c == c' && b == b' then (
+            Visitor.SkipChildren
+          ) else (
+            Visitor.ChangeTo [Stmt_Repeat (b' @ Asl_utils.mk_assigns loc lets, c', pos, loc)]
+          )
+      | _ ->
+          let rebuild (xs : AST.stmt list) : AST.stmt list =
+            let loc = Loc.Unknown in
+            let lets = bindings in
+            bindings <- [];
+            (Asl_utils.mk_assigns loc lets) @ xs
+          in
+          Visitor.ChangeDoChildrenPost ([x], rebuild)
+      )
+
+    method !vs_elsif x =
+      ( match x with
+      | S_Elsif_Cond (c, b, loc) ->
+          let c' = self#hoist_lets_to_expression_top c in
+          let b' = visit_stmts (self :> aslVisitor) b in
+          if c == c' && b == b' then (
+            Visitor.SkipChildren
+          ) else (
+            Visitor.ChangeTo (S_Elsif_Cond (c', b', loc))
+          )
+      )
+
+    method !ve_elsif x =
+      ( match x with
+      | E_Elsif_Cond (c, e) ->
+          let c' = self#hoist_lets_to_expression_top c in
+          let e' = self#hoist_lets_to_expression_top e in
+          if c == c' && e == e' then (
+            Visitor.SkipChildren
+          ) else (
+            Visitor.ChangeTo (E_Elsif_Cond (c', e'))
+          )
+      )
+
+    method !valt x =
+      ( match x with
+      | Alt_Alt (ps, oc, b, loc) ->
+          let oc' = Visitor.mapOptionNoCopy self#hoist_lets_to_expression_top oc in
+          let b' = visit_stmts (self :> aslVisitor) b in
+          if oc == oc' && b == b' then (
+            Visitor.SkipChildren
+          ) else (
+            Visitor.ChangeTo (Alt_Alt (ps, oc', b', loc))
+          )
+      )
+end
+
+let xform_decls (ds : AST.declaration list) : AST.declaration list =
+  let transformer = new hoist_lets (Some ds) in
+  List.map (Asl_visitor.visit_decl (transformer :> Asl_visitor.aslVisitor)) ds
+
+(****************************************************************
+ * Command: :xform_hoist_lets
+ ****************************************************************)
+
+let _ =
+  let cmd (tcenv : Tcheck.Env.t) (cpu : Cpu.cpu) : bool =
+    Commands.declarations := xform_decls !Commands.declarations;
+    true
+  in
+  let options = [] in
+  Commands.registerCommand "xform_hoist_lets" options [] [] "Hoist let-expressions" cmd
+
+(****************************************************************
+ * End
+ ****************************************************************)

--- a/libASL/xform_hoist_lets.mli
+++ b/libASL/xform_hoist_lets.mli
@@ -1,0 +1,31 @@
+(****************************************************************
+ * ASL let-hoisting transform
+ *
+ * Lifts let-bindings as high as possible out of expressions.
+ *
+ * The main restrictions on lifting let-bindings are
+ *
+ * - not lifting the let-binding out of a while guard condition
+ *   in case the let-binding depends on a variable that is modified
+ *   by the while loop or has side-effects.
+ *
+ * - not lifting the let-binding out of elsif conditions, case-alternative
+ *   guards or catcher-guards in case the let-binding is evaluated
+ *   earlier than other conditions/guards in the statement.
+ *
+ * - not lifting the let-binding out of the body of an if-expression
+ *   or out of the second argument of && or || in case the let-binding
+ *   contains a side-effect or can throw an exception or can
+ *   trigger a runtime error.
+ *
+ * When these restrictions do not limit how high a binding can be lifted,
+ * they normally turn into assignments prior to the statement that
+ * contains the expression.
+ *
+ * Copyright (C) 2025-2025 Intel Corporation
+ * SPDX-Licence-Identifier: BSD-3-Clause
+ ****************************************************************)
+
+(****************************************************************
+ * End
+ ****************************************************************)

--- a/libASL/xform_lower.ml
+++ b/libASL/xform_lower.ml
@@ -15,18 +15,6 @@ open Asl_utils
 
 let assign_var = new Asl_utils.nameSupply "__l"
 
-(* Construct nested let-expressions from a list of bindings
- *
- *     mk_lets [(x, tx, ex); (y, ty, ey)] e
- *   =
- *     let x:tx = ex in (let y:ty = ey in e)
- *)
-let rec mk_let_exprs (bindings : (Ident.t * AST.ty * AST.expr) list) (e : AST.expr) : AST.expr =
-  ( match bindings with
-  | [] -> e
-  | ((v, ty, e') :: bs) -> AST.Expr_Let(v, ty, e', mk_let_exprs bs e)
-  )
-
 class lower_class = object (self)
     inherit Asl_visitor.nopAslVisitor
 

--- a/tests/lit/xform_hoist_lets/test_00.asl
+++ b/tests/lit/xform_hoist_lets/test_00.asl
@@ -1,0 +1,15 @@
+// RUN: %asli --batchmode --exec=:xform_hoist_lets --exec=":show --format=raw FUT" %s | filecheck %s
+// Copyright (C) 2025-2025 Intel Corporation
+
+func FUT(x : bits(32), i : integer {0..32}) => boolean
+begin
+    // The original motivating example - this prevented use
+    // of a transformation that looked for "IsZero(x[_ +: _])"
+    return IsZero(__let wd : integer = 32-i __in
+                  __let ix : integer = 31-i __in
+                  x[ix +: wd]);
+end
+
+// CHECK: let wd : integer = asl_sub_int.0{}(32, i);
+// CHECK: let ix : integer = asl_sub_int.0{}(31, i);
+// CHECK: return IsZero.0{wd}({bits(32)}x[ix +: wd]);

--- a/tests/lit/xform_hoist_lets/test_01.asl
+++ b/tests/lit/xform_hoist_lets/test_01.asl
@@ -1,0 +1,59 @@
+// RUN: %asli --batchmode --exec=:xform_hoist_lets --exec=":show --format=raw FUT" %s | filecheck %s
+// Copyright (C) 2025-2025 Intel Corporation
+
+func FUT(i : integer) => boolean
+begin
+    // Check that lets are not lifted past sequencing points
+
+    // AND
+    let r1 = i >= 0 && (__let t : integer = 10 __in i <= t);
+    // CHECK: asl_and_bool.0{}(asl_ge_int.0{}(i, 0), __let t : integer = 10 __in asl_le_int.0{}(i, t));
+    let r2 = i >= 0 && i <= (__let t : integer = 10 __in t);
+    // CHECK: asl_and_bool.0{}(asl_ge_int.0{}(i, 0), __let t : integer = 10 __in asl_le_int.0{}(i, t));
+
+    // OR
+    let r3 = i >= 0 || i <= (__let t : integer = 10 __in t);
+    // CHECK: asl_or_bool.0{}(asl_ge_int.0{}(i, 0), __let t : integer = 10 __in asl_le_int.0{}(i, t));
+
+    // IMPLIES
+    let r4 = i >= 0 --> i <= (__let t : integer = 10 __in t);
+    // CHECK: asl_implies_bool.0{}(asl_ge_int.0{}(i, 0), __let t : integer = 10 __in asl_le_int.0{}(i, t));
+
+    // IF expression
+    let r5 = if i >= 0 then i <= (__let t : integer = 10 __in t) else FALSE;
+    // CHECK: if asl_ge_int.0{}(i, 0) then __let t : integer = 10 __in asl_le_int.0{}(i, t) else FALSE;
+
+    // IF statement
+    if __let b1 : boolean = i >= 0 __in b1 then
+        let r6 = i <= (__let t : integer = 10 __in t);
+    else
+        let r7 = i <= (__let t : integer = 10 __in t);
+    end
+    // CHECK:       let b1 : boolean = asl_ge_int.0{}(i, 0);
+    // CHECK-NEXT:  if b1 then
+    // CHECK-NEXT:      let t : integer = 10;
+    // CHECK-NEXT:      let r6 : boolean = asl_le_int.0{}(i, t);
+    // CHECK-NEXT:  else
+    // CHECK-NEXT:      let t : integer = 10;
+    // CHECK-NEXT:      let r7 : boolean = asl_le_int.0{}(i, t);
+    // CHECK-NEXT:  end
+
+    // WHILE loop
+    while i <= (__let t : integer = 10 __in t) do
+    end
+    // CHECK:       while __let t : integer = 10 __in asl_le_int.0{}(i, t) do
+    // CHECK-NEXT:  
+    // CHECK-NEXT:  end
+
+    // REPEAT loop
+    repeat
+        let x = 42;
+    until i <= (__let t : integer = 10 __in t);
+    // CHECK:       repeat
+    // CHECK-NEXT:      let x : integer{42} = 42;
+    // CHECK-NEXT:      let t : integer = 10;
+    // CHECK-NEXT:  until asl_le_int.0{}(i, t);
+
+    return r1 && r2 && r3 && r4 && r5;
+end
+


### PR DESCRIPTION
This transformation moves let expressions as high as possible in an expression.

For example, it turns code like 

```
y = IsZero(__let i = F(x) __in x[i +: w]);
```

into

```
let i = F(x);
y = IsZero(x[i +: w]);
```

This is important because there is an optimization for "IsZero(x[i +: w]);" that only works if the function call is right next to the bitslice operation.