### PR TITLE
Github workflow: use older ubuntu

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out


### PR DESCRIPTION
With ubuntu-latest, we can no longer install clang-16 using the llvm.sh script. It seems that the llvm.sh script broke when 22.04 was first released so maybe this is a temporary blip because ubuntu-latest just changed to 22.04.1.

This crude workaround just uses an older version of Ubuntu - hopefully fixing the problem until we are ready to change to using clang-17 or later.