### PR TITLE
Fix duplicate prototypes

### DIFF
--- a/libASL/backend_c.ml
+++ b/libASL/backend_c.ml
@@ -1410,14 +1410,7 @@ let type_decls (xs : AST.declaration list) : AST.declaration list =
     | Decl_FunType _
       -> Some x
 
-    (* Add Fun/Proc-Type declarations for any functions that have been created
-     * after typechecking such as functions created during monomorphization.
-     * Since the typechecker creates Fun/Proc-Type declarations for all functions
-     * in the original spec, this will result in duplicate function prototypes
-     * for many functions.
-     *)
-    | Decl_FunDefn (f, fty, b, loc) -> Some (Decl_FunType (f, fty, loc))
-
+    | Decl_FunDefn _
     | Decl_Const _
     | Decl_Exception _
     | Decl_Var _

--- a/libASL/backend_c_new.ml
+++ b/libASL/backend_c_new.ml
@@ -1161,14 +1161,7 @@ let type_decls (xs : AST.declaration list) : AST.declaration list =
     | Decl_FunType _
       -> Some x
 
-    (* Add Fun/Proc-Type declarations for any functions that have been created
-     * after typechecking such as functions created during monomorphization.
-     * Since the typechecker creates Fun/Proc-Type declarations for all functions
-     * in the original spec, this will result in duplicate function prototypes
-     * for many functions.
-     *)
-    | Decl_FunDefn (f, fty, b, loc) -> Some (Decl_FunType (f, fty, loc))
-
+    | Decl_FunDefn _
     | Decl_Const _
     | Decl_Exception _
     | Decl_Var _
@@ -1687,9 +1680,6 @@ let mk_ffi_wrappers (is_import : bool) (decl_map : (AST.declaration list) Bindin
       let c_ident = Ident.mk_ident c_name in
       ( match Bindings.find_opt asl_ident decl_map with
       | Some (Decl_FunType (_, fty, loc) :: _) -> Some (c_ident, asl_ident, fty, loc)
-      | Some (Decl_FunDefn (_, fty, _, loc) :: _) -> Some (c_ident, asl_ident, fty, loc)
-      | _ when is_enumerated_type c_ident ->
-          None
       | _ ->
           if not (is_enumerated_type c_ident) then begin
               missing := c_name :: !missing

--- a/libASL/backend_c_new.ml
+++ b/libASL/backend_c_new.ml
@@ -1691,7 +1691,9 @@ let mk_ffi_wrappers (is_import : bool) (decl_map : (AST.declaration list) Bindin
       | _ when is_enumerated_type c_ident ->
           None
       | _ ->
-          missing := c_name :: !missing;
+          if not (is_enumerated_type c_ident) then begin
+              missing := c_name :: !missing
+          end;
           None
       )
     ) c_names
@@ -1771,7 +1773,8 @@ let mk_ffi_config (decls : AST.declaration list) : (string list * AST.declaratio
       }
     in
     let getter_body = [ AST.Stmt_FunReturn (Expr_Var v, loc) ] in
-    let getter = AST.Decl_FunDefn (getter_id, getter_fty, getter_body, loc) in
+    let getter_defn = AST.Decl_FunDefn (getter_id, getter_fty, getter_body, loc) in
+    let getter_type = AST.Decl_FunType (getter_id, getter_fty, loc) in
 
     let setter_name = config_setter_prefix ^ Ident.name v in
     let setter_id = Ident.mk_fident setter_name in
@@ -1787,9 +1790,10 @@ let mk_ffi_config (decls : AST.declaration list) : (string list * AST.declaratio
       }
     in
     let setter_body = [ AST.Stmt_Assign (LExpr_Var v, Expr_Var setter_arg, loc) ] in
-    let setter = AST.Decl_FunDefn (setter_id, setter_fty, setter_body, loc) in
+    let setter_defn = AST.Decl_FunDefn (setter_id, setter_fty, setter_body, loc) in
+    let setter_type = AST.Decl_FunType (setter_id, setter_fty, loc) in
 
-    ([getter_name; setter_name], [getter; setter])
+    ([getter_name; setter_name], [getter_defn; getter_type; setter_defn; setter_type])
   in
 
   let (names, decls) = List.map mk_functions configs |> List.split in

--- a/libASL/backend_cpp.ml
+++ b/libASL/backend_cpp.ml
@@ -1570,14 +1570,7 @@ let type_decls (xs : AST.declaration list) : AST.declaration list =
     | Decl_FunType _
       -> Some x
 
-    (* Add Fun/Proc-Type declarations for any functions that have been created
-     * after typechecking such as functions created during monomorphization.
-     * Since the typechecker creates Fun/Proc-Type declarations for all functions
-     * in the original spec, this will result in duplicate function prototypes
-     * for many functions.
-     *)
-    | Decl_FunDefn (f, fty, b, loc) -> Some (Decl_FunType (f, fty, loc))
-
+    | Decl_FunDefn _
     | Decl_Const _
     | Decl_Exception _
     | Decl_Var _

--- a/libASL/tcheck.ml
+++ b/libASL/tcheck.ml
@@ -2552,7 +2552,7 @@ let tc_declarations (env : GlobalEnv.t) ~(isPrelude : bool) ~(sort_decls : bool)
    * Note that each declaration is evaluated in a separate local environment
    * but that they share the same global environment
    *)
-  let pre, post = if isPrelude then (ds, []) else genPrototypes ds in
+  let (pre, post) = genPrototypes ds in
   let pre = if sort_decls then List.rev (Asl_utils.topological_sort pre) else pre in
   if verbose then
     Format.fprintf fmt "  - Typechecking %d phase declarations\n"


### PR DESCRIPTION
This cleans up a minor issue in C code generation #35 

The problem was that we generated duplicate C function prototypes: some came from ASL function definitions (Decl_FunDefn) and some came from ASL function prototypes (Decl_FunType) and we generated duplicates when we had both a Defn and a Type for the same function (almost all the time).

The fix is to ensure that we always have a FunType for every ASL function so that we can consistently generate C function prototypes from the FunType and never need to use the FunDefn.
This required two changes in places that generate prototypes:
1) We treated Prelude functions differently in the past - but the need to do this has long since been fixed.
2) The monomorphism transformations was not generating function prototypes for new instances - trivial to fix.

With these fixed, we are able to make a minor simplification in the C/C++ backends.