### PR TITLE
Runtime checking

### DIFF
--- a/bin/asl2c.py
+++ b/bin/asl2c.py
@@ -217,9 +217,11 @@ def report(x):
 # (The assumption is that the command printed a useful/meaningful error message already)
 def run(cmd):
     report(" ".join(cmd))
-    r = subprocess.run(cmd)
-    if r.returncode != 0:
-        exit(r.returncode)
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as e:
+        print(f"Command '{' '.join(e.cmd)}' returned non-zero exit status {e.returncode}.")
+        sys.exit(e.returncode)
 
 ################################################################
 # Compile/link flags

--- a/bin/asli.ml
+++ b/bin/asli.ml
@@ -140,8 +140,8 @@ let rec process_command (tcenv : TC.Env.t) (cpu : Cpu.cpu) (fname : string) (inp
      ()
   | _ ->
       if ';' = String.get input (String.length input - 1) then
-        let s = LoadASL.read_stmt tcenv input in
-        Eval.eval_stmt cpu.env s
+        let ss = LoadASL.read_stmt tcenv input in
+        List.iter (Eval.eval_stmt cpu.env) ss
       else
         let loc = mkLoc fname input in
         let e = LoadASL.read_expr tcenv loc input in
@@ -377,6 +377,8 @@ let options =
       ("--nocheck-call-markers",      Arg.Clear Global_checks.check_call_markers, "       Do not check that function calls have correct exception markers");
       ("--check-constraints", Arg.Set Tcheck.enable_constraint_checks,     "       Check type constraints");
       ("--nocheck-constraints", Arg.Clear Tcheck.enable_constraint_checks, "       Do not check type constraints");
+      ("--runtime-check",           Arg.Set Tcheck.enable_runtime_checks,         "       Insert runtime checks");
+      ("--noruntime-checks",        Arg.Clear Tcheck.enable_runtime_checks,       "       Do not insert runtime checks");
     ]
 
 let version = "ASLi 1.0.0"

--- a/libASL/asl_ast.ml
+++ b/libASL/asl_ast.ml
@@ -70,6 +70,7 @@ pattern =
 and expr =
    Expr_If of expr * expr * e_elsif list * expr
  | Expr_Let of Ident.t * ty * expr * expr (* IR extension, not intended for use in specs *)
+ | Expr_Assert of expr * expr * Loc.t (* IR extension, not intended for use in specs *)
  | Expr_Binop of expr * binop * expr
  | Expr_Unop of unop * expr (* unary operator *)
  | Expr_Field of expr * Ident.t (* field selection *)

--- a/libASL/asl_fmt.ml
+++ b/libASL/asl_fmt.ml
@@ -409,6 +409,10 @@ and expr (fmt : PP.formatter) (x : AST.expr) : unit =
         ty t
         expr e
         expr b
+  | Expr_Assert (e1, e2, loc) ->
+      Format.fprintf fmt "__assert %a __in %a"
+        expr e1
+        expr e2
   | Expr_Binop (a, op, b) ->
       expr fmt a;
       nbsp fmt;

--- a/libASL/asl_parser.mly
+++ b/libASL/asl_parser.mly
@@ -27,6 +27,7 @@ open Loc
 let type_unknown = Type_Constructor (Ident.mk_ident "<type_unknown>", [])
 %}
 
+%token UNDERSCORE_UNDERSCORE_ASSERT  (* __assert *)
 %token UNDERSCORE_UNDERSCORE_BUILTIN  (* __builtin *)
 %token UNDERSCORE_UNDERSCORE_IN   (* __in *)
 %token UNDERSCORE_UNDERSCORE_LET  (* __let *)
@@ -504,6 +505,8 @@ conditional_expression:
     { Expr_If(c, t, els, e) }
 | UNDERSCORE_UNDERSCORE_LET v = ident COLON ty = ty EQ e = expr UNDERSCORE_UNDERSCORE_IN b = expr
     { Expr_Let(v, ty, e, b) }
+| UNDERSCORE_UNDERSCORE_ASSERT e1 = expr UNDERSCORE_UNDERSCORE_IN e2 = expr
+    { Expr_Assert(e1, e2, Range($symbolstartpos, $endpos)) }
 | cexpr = cexpr { cexpr }
 
 e_elsif:

--- a/libASL/asl_utils.ml
+++ b/libASL/asl_utils.ml
@@ -942,6 +942,9 @@ let mk_ne_int (x : AST.expr) (y : AST.expr) : AST.expr = mk_binop ne_int [] x y
 (** Construct "le_int(x, y)" *)
 let mk_le_int (x : AST.expr) (y : AST.expr) : AST.expr = mk_binop le_int [] x y
 
+(** Construct "lt_int(x, y)" *)
+let mk_lt_int (x : AST.expr) (y : AST.expr) : AST.expr = mk_binop lt_int [] x y
+
 (** Construct "add_int(x, y)" *)
 let mk_add_int (x : AST.expr) (y : AST.expr) : AST.expr =
   if x = zero then y

--- a/libASL/asl_utils.ml
+++ b/libASL/asl_utils.ml
@@ -936,6 +936,9 @@ let mk_eq_enum (x : AST.expr) (y : AST.expr) : AST.expr = mk_binop eq_enum [] x 
 (** Construct "eq_int(x, y)" *)
 let mk_eq_int (x : AST.expr) (y : AST.expr) : AST.expr = mk_binop eq_int [] x y
 
+(** Construct "ne_int(x, y)" *)
+let mk_ne_int (x : AST.expr) (y : AST.expr) : AST.expr = mk_binop ne_int [] x y
+
 (** Construct "le_int(x, y)" *)
 let mk_le_int (x : AST.expr) (y : AST.expr) : AST.expr = mk_binop le_int [] x y
 
@@ -961,6 +964,10 @@ let mk_mul_int (x : AST.expr) (y : AST.expr) : AST.expr =
   else if x = minus_one then mk_neg_int y
   else if y = minus_one then mk_neg_int x
   else mk_binop mul_int [] x y
+
+(** Construct "zrem_int(x, y)" *)
+let mk_zrem_int (x : AST.expr) (y : AST.expr) : AST.expr =
+  mk_binop zrem_int [] x y
 
 (** Construct "pow_int_int(x, y)" *)
 let mk_pow_int_int (x : AST.expr) (y : AST.expr) : AST.expr =

--- a/libASL/asl_utils.mli
+++ b/libASL/asl_utils.mli
@@ -377,13 +377,15 @@ val mk_cvt_int_bits : AST.expr -> AST.expr -> AST.expr
 (** {2 Let expressions}                                         *)
 (****************************************************************)
 
+type binding = (Ident.t * AST.ty * AST.expr)
+
 (** Construct nested let-expressions from a list of bindings
  *
  *     mk_let_exprs [(x, tx, ex); (y, ty, ey)] e
  *   =
  *     let x:tx = ex in (let y:ty = ey in e)
  *)
-val mk_let_exprs : (Ident.t * AST.ty * AST.expr) list -> AST.expr -> AST.expr
+val mk_let_exprs : binding list -> AST.expr -> AST.expr
 
 (** Construct assignments from a list of bindings
  *
@@ -392,7 +394,30 @@ val mk_let_exprs : (Ident.t * AST.ty * AST.expr) list -> AST.expr -> AST.expr
  *     let x : tx = ex;
  *     let y : ty = ey;
  *)
-val mk_assigns : Loc.t -> (Ident.t * AST.ty * AST.expr) list -> AST.stmt list
+val mk_assigns : Loc.t -> binding list -> AST.stmt list
+
+(****************************************************************)
+(** {2 Assert expressions and statements}                       *)
+(****************************************************************)
+
+type check = (AST.expr * Loc.t)
+
+(* Construct nested assert-expressions from a list of checks
+ *
+ *     mk_assert [(x, locx); (y, locy)] e
+ *   =
+ *     __assert x __in (__assert y in e)
+ *)
+val mk_assert_exprs : check list -> AST.expr -> AST.expr
+
+(* Construct assertion statements from a list of checks
+ *
+ *     mk_assert [(x, locx); (y, locy)] e
+ *   =
+ *     assert x;
+ *     assert y;
+ *)
+val mk_assert_stmts : (AST.expr * Loc.t) list -> AST.stmt list
 
 (****************************************************************)
 (** {2 Safe expressions}                                        *)

--- a/libASL/asl_utils.mli
+++ b/libASL/asl_utils.mli
@@ -292,6 +292,9 @@ val mk_ne_int : AST.expr -> AST.expr -> AST.expr
 (** Construct "le_int(x, y)" *)
 val mk_le_int : AST.expr -> AST.expr -> AST.expr
 
+(** Construct "lt_int(x, y)" *)
+val mk_lt_int : AST.expr -> AST.expr -> AST.expr
+
 (** Construct "add_int(x, y)" *)
 val mk_add_int : AST.expr -> AST.expr -> AST.expr
 

--- a/libASL/asl_utils.mli
+++ b/libASL/asl_utils.mli
@@ -286,6 +286,9 @@ val mk_eq_enum : AST.expr -> AST.expr -> AST.expr
 (** Construct "eq_int(x, y)" *)
 val mk_eq_int : AST.expr -> AST.expr -> AST.expr
 
+(** Construct "ne_int(x, y)" *)
+val mk_ne_int : AST.expr -> AST.expr -> AST.expr
+
 (** Construct "le_int(x, y)" *)
 val mk_le_int : AST.expr -> AST.expr -> AST.expr
 
@@ -300,6 +303,9 @@ val mk_neg_int : AST.expr -> AST.expr
 
 (** Construct "mul_int(x, y)" *)
 val mk_mul_int : AST.expr -> AST.expr -> AST.expr
+
+(** Construct "zrem_int(x, y)" *)
+val mk_zrem_int : AST.expr -> AST.expr -> AST.expr
 
 (** Construct "pow_int_int(x, y)" *)
 val mk_pow_int_int : AST.expr -> AST.expr -> AST.expr

--- a/libASL/asl_visitor.ml
+++ b/libASL/asl_visitor.ml
@@ -159,6 +159,11 @@ and visit_expr (vis : aslVisitor) (x : expr) : expr =
         let b' = visit_expr vis b in
         if v == v' && t == t' && e == e' && b == b' then x
         else Expr_Let (v', t', e', b')
+    | Expr_Assert (e1, e2, loc) ->
+        let e1' = visit_expr vis e1 in
+        let e2' = visit_expr vis e2 in
+        if e1 == e1' && e2 == e2' then x
+        else Expr_Assert (e1', e2', loc)
     | Expr_Binop (a, op, b) ->
         let a' = visit_expr vis a in
         let b' = visit_expr vis b in

--- a/libASL/backend_c.ml
+++ b/libASL/backend_c.ml
@@ -821,6 +821,12 @@ and expr (loc : Loc.t) (fmt : PP.formatter) (x : AST.expr) : unit =
       Format.fprintf fmt " = %a; %a; })"
         (expr loc) e
         (expr loc) b
+  | Expr_Assert (e1, e2, loc) ->
+      PP.fprintf fmt "({ ASL_assert(\"%s\", \"%s\", %a); %a; })"
+        (String.escaped (Loc.to_string loc))
+        (String.escaped (Utils.to_string2 (Fun.flip FMT.expr e1)))
+        (expr loc) e1
+        (expr loc) e2;
   | Expr_Lit v -> valueLit loc fmt v
   | Expr_RecordInit (tc, [], fas) ->
       if List.mem tc !exception_tcs then begin

--- a/libASL/backend_c_new.ml
+++ b/libASL/backend_c_new.ml
@@ -259,7 +259,13 @@ let rethrow_stmt (fmt : PP.formatter) : unit =
     ident (current_catch_label ())
 
 let rethrow_expr (fmt : PP.formatter) (f : unit -> unit) : unit =
-  PP.fprintf fmt "({ __auto_type __r = ";
+  PP.fprintf fmt "({ ";
+  if !is_cxx then begin
+    PP.fprintf fmt "auto __r = "
+  end else begin
+    (* __auto_type is a gcc extension (also supported by clang) *)
+    PP.fprintf fmt "__auto_type __r = "
+  end;
   f ();
   PP.fprintf fmt "; ";
   rethrow_stmt fmt;

--- a/libASL/backend_c_new.ml
+++ b/libASL/backend_c_new.ml
@@ -527,6 +527,12 @@ and expr (loc : Loc.t) (fmt : PP.formatter) (x : AST.expr) : unit =
       PP.fprintf fmt " = %a; %a; })"
         (expr loc) e
         (expr loc) b
+  | Expr_Assert (e1, e2, loc) ->
+      PP.fprintf fmt "({ ASL_assert(\"%s\", \"%s\", %a); %a; })"
+        (String.escaped (Loc.to_string loc))
+        (String.escaped (Utils.to_string2 (Fun.flip FMT.expr e1)))
+        (expr loc) e1
+        (expr loc) e2;
   | Expr_Lit v -> valueLit loc fmt v
   | Expr_RecordInit (tc, [], fas) ->
       if List.mem tc !exception_tcs then begin

--- a/libASL/backend_cpp.ml
+++ b/libASL/backend_cpp.ml
@@ -919,6 +919,12 @@ and expr (loc : Loc.t) (fmt : PP.formatter) (x : AST.expr) : unit =
       Format.fprintf fmt " = %a; %a; })"
         (expr loc) e
         (expr loc) b
+  | Expr_Assert (e1, e2, loc) ->
+      PP.fprintf fmt "({ ASL_assert(\"%s\", \"%s\", %a); %a; })"
+        (String.escaped (Loc.to_string loc))
+        (String.escaped (Utils.to_string2 (Fun.flip FMT.expr e1)))
+        (expr loc) e1
+        (expr loc) e2;
   | Expr_Lit v -> valueLit loc fmt v
   | Expr_RecordInit (tc, [], fas) ->
       if List.mem tc !exception_tcs then begin

--- a/libASL/eval.ml
+++ b/libASL/eval.ml
@@ -331,6 +331,11 @@ and eval_expr (loc : Loc.t) (env : Env.t) (x : AST.expr) : value =
         Env.addLocalConst loc env v e';
         eval_expr loc env b
       )
+  | Expr_Assert (e1, e2, loc) ->
+      if not (to_bool loc (eval_expr loc env e1)) then begin
+        raise (EvalError (loc, "assertion failure"));
+      end;
+      eval_expr loc env e2
   | Expr_Binop (a, op, b) ->
       raise
         (EvalError

--- a/libASL/lexer.mll
+++ b/libASL/lexer.mll
@@ -24,6 +24,7 @@ let keywords : (string * Asl_parser.token) list = [
     ("REM",                    REM);
     ("UNKNOWN",                UNKNOWN);
     ("XOR",                    EOR);
+    ("__assert",               UNDERSCORE_UNDERSCORE_ASSERT);
     ("__builtin",              UNDERSCORE_UNDERSCORE_BUILTIN);
     ("__in",                   UNDERSCORE_UNDERSCORE_IN);
     ("__let",                  UNDERSCORE_UNDERSCORE_LET);

--- a/libASL/lexersupport.ml
+++ b/libASL/lexersupport.ml
@@ -23,6 +23,7 @@ let string_of_token (t : Asl_parser.token) : string =
   | BITS -> "bits"
   | BEGIN -> "begin"
   | BITSLIT x -> Value.string_of_value (VBits x)
+  | UNDERSCORE_UNDERSCORE_ASSERT -> "__assert"
   | UNDERSCORE_UNDERSCORE_BUILTIN -> "__builtin"
   | UNDERSCORE_UNDERSCORE_IN -> "__in"
   | UNDERSCORE_UNDERSCORE_LET -> "__let"

--- a/libASL/loadASL.ml
+++ b/libASL/loadASL.ml
@@ -203,7 +203,7 @@ let read_expr (tcenv : TC.Env.t) (loc : Loc.t) (s : string) : AST.expr =
   let e', _ = TC.tc_expr tcenv loc e in
   e'
 
-let read_stmt (tcenv : TC.Env.t) (s : string) : AST.stmt =
+let read_stmt (tcenv : TC.Env.t) (s : string) : AST.stmt list =
   let lexbuf = Lexing.from_string s in
   let s = Parser.stmt_command_start Lexer.token lexbuf in
   TC.tc_stmt tcenv s

--- a/libASL/loadASL.mli
+++ b/libASL/loadASL.mli
@@ -23,7 +23,7 @@ val read_files : string list -> string list -> bool -> Asl_ast.declaration list
 
 val read_config : TC.Env.t -> Loc.t -> string -> Ident.t * AST.expr * AST.ty
 val read_expr : TC.Env.t -> Loc.t -> string -> AST.expr
-val read_stmt : TC.Env.t -> string -> AST.stmt
+val read_stmt : TC.Env.t -> string -> AST.stmt list
 val read_stmts : TC.Env.t -> string -> AST.stmt list
 val read_declarations_unsorted : TC.GlobalEnv.t -> string -> AST.declaration list
 

--- a/libASL/tcheck.ml
+++ b/libASL/tcheck.ml
@@ -1439,6 +1439,10 @@ and tc_expr (env : Env.t) (loc : Loc.t) (x : AST.expr) :
           (Expr_Let (v, t', e', b'), bty')
         )
         env
+  | Expr_Assert (e1, e2, loc) ->
+      let e1' = check_expr env loc type_bool e1 in
+      let (e2', ty') = tc_expr env loc e2 in
+      (Expr_Assert (e1', e2', loc), ty')
   | Expr_Binop (x, Binop_Eq, Expr_Lit (VMask _ as m)) ->
       (* syntactic sugar *)
       tc_expr env loc (Expr_In (x, Pat_Lit m))

--- a/libASL/xform_constprop.ml
+++ b/libASL/xform_constprop.ml
@@ -239,6 +239,13 @@ class constEvalClass (env : Env.t) =
             else
               Visitor.ChangeTo (Expr_Let (v, t', e', b'))
             )
+      | Expr_Assert (e1, e2, loc) ->
+          let e1' = self#eval_expr e1 in
+          let e2' = self#eval_expr e2 in
+          if e1' = asl_true then
+              Visitor.ChangeTo e2'
+          else if e1 == e1' && e2 == e2' then SkipChildren
+          else Visitor.ChangeTo (Expr_Assert (e1', e2', loc))
       | Expr_Slices (t, e, ss) ->
           let t' = self#eval_type t in
           let e' = self#eval_expr e in

--- a/libASL/xform_hoist_lets.ml
+++ b/libASL/xform_hoist_lets.ml
@@ -1,26 +1,27 @@
 (****************************************************************
  * ASL let-hoisting transform
  *
- * Lifts let-bindings as high as possible out of expressions.
+ * Lifts let-bindings and expression-asserts as high as possible
+ * out of expressions.
  *
- * The main restrictions on lifting let-bindings are
+ * The main restrictions on lifting let-bindings/asserts are
  *
- * - not lifting the let-binding out of a while guard condition
+ * - not lifting the let-binding/assert out of a while guard condition
  *   in case the let-binding depends on a variable that is modified
- *   by the while loop or has side-effects.
+ *   by the while loop or has side-effects or the assertion fails.
  *
- * - not lifting the let-binding out of elsif conditions, case-alternative
+ * - not lifting the let-binding/assert out of elsif conditions, case-alternative
  *   guards or catcher-guards in case the let-binding is evaluated
  *   earlier than other conditions/guards in the statement.
  *
- * - not lifting the let-binding out of the body of an if-expression
+ * - not lifting the let-binding/assert out of the body of an if-expression
  *   or out of the second argument of && or || in case the let-binding
  *   contains a side-effect or can throw an exception or can
  *   trigger a runtime error.
  *
- * When these restrictions do not limit how high a binding can be lifted,
- * they normally turn into assignments prior to the statement that
- * contains the expression.
+ * When these restrictions do not limit how high a binding/assert
+ * can be lifted, they normally turn into assignments prior to the
+ * statement that contains the expression.
  *
  * Copyright (C) 2025-2025 Intel Corporation
  * SPDX-Licence-Identifier: BSD-3-Clause
@@ -30,26 +31,29 @@ module AST = Asl_ast
 open Asl_visitor
 open Builtin_idents
 
-type binding = (Ident.t * AST.ty * AST.expr)
-
 class hoist_lets (ds : AST.declaration list option) = object (self)
     inherit nopAslVisitor
 
-    val mutable bindings : binding list = []
+    val mutable bindings : Asl_utils.binding list = []
+    val mutable checks : Asl_utils.check list = []
 
-    (* Hoist let-expressions out of an expression *)
-    method hoist_lets_out_of_expression (x : AST.expr) : (binding list * AST.expr) =
-      let old = bindings in
+    (* Hoist let-expressions and assertions out of an expression *)
+    method hoist_lets_out_of_expression (x : AST.expr) : (Asl_utils.binding list * Asl_utils.check list * AST.expr) =
+      let old_bindings = bindings in
+      let old_checks = checks in
       bindings <- [];
+      checks <- [];
       let x' = visit_expr (self :> aslVisitor) x in
-      let binds = bindings in
-      bindings <- old;
-      (binds, x')
+      let lets = bindings in
+      let asserts = checks in
+      bindings <- old_bindings;
+      checks <- old_checks;
+      (lets, asserts, x')
 
     (* Hoist let-expressions to the top of expression *)
     method hoist_lets_to_expression_top (x : AST.expr) : AST.expr =
-      let (lets, x') = self#hoist_lets_out_of_expression x in
-      Asl_utils.mk_let_exprs lets x'
+      let (lets, asserts, x') = self#hoist_lets_out_of_expression x in
+      Asl_utils.mk_let_exprs lets (Asl_utils.mk_assert_exprs asserts x')
 
     method! vexpr x =
       ( match x with
@@ -57,6 +61,11 @@ class hoist_lets (ds : AST.declaration list option) = object (self)
           let e1' = visit_expr (self :> aslVisitor) e1 in
           let e2' = visit_expr (self :> aslVisitor) e2 in
           bindings <- (x, ty, e1') :: bindings;
+          Visitor.ChangeTo e2'
+      | Expr_Assert (e1, e2, loc) ->
+          let e1' = visit_expr (self :> aslVisitor) e1 in
+          let e2' = visit_expr (self :> aslVisitor) e2 in
+          checks <- (e1', loc) :: checks;
           Visitor.ChangeTo e2'
       | Expr_TApply (f, [], [a; b], NoThrow) when Ident.in_list f [and_bool; or_bool; implies_bool] ->
           let a' = visit_expr (self :> aslVisitor) a in
@@ -84,14 +93,16 @@ class hoist_lets (ds : AST.declaration list option) = object (self)
       assert (Utils.is_empty bindings);
       ( match x with
       | Stmt_If (c, t, els, (e, el), loc) ->
-          let (lets, c') = self#hoist_lets_out_of_expression c in
+          let (lets, asserts, c') = self#hoist_lets_out_of_expression c in
           let t' = visit_stmts (self :> aslVisitor) t in
           let els' = Visitor.mapNoCopy (visit_s_elsif (self :> aslVisitor)) els in
           let e' = visit_stmts (self :> aslVisitor) e in
-          if Utils.is_empty lets && c == c' && t == t' && els == els' && e == e' then (
+          if Utils.is_empty lets && Utils.is_empty asserts && c == c' && t == t' && els == els' && e == e' then (
             Visitor.SkipChildren
           ) else (
-            Visitor.ChangeTo (Asl_utils.mk_assigns loc lets @ [Stmt_If (c', t', els', (e', el), loc)])
+            let lets' = Asl_utils.mk_assigns loc lets in
+            let asserts' = Asl_utils.mk_assert_stmts asserts in
+            Visitor.ChangeTo (lets' @ asserts' @ [Stmt_If (c', t', els', (e', el), loc)])
           )
       | Stmt_While (c, b, loc) ->
           let c' = self#hoist_lets_to_expression_top c in
@@ -103,18 +114,24 @@ class hoist_lets (ds : AST.declaration list option) = object (self)
           )
       | Stmt_Repeat (b, c, pos, loc) ->
           let b' = visit_stmts (self :> aslVisitor) b in
-          let (lets, c') = self#hoist_lets_out_of_expression c in
-          if Utils.is_empty lets && c == c' && b == b' then (
+          let (lets, asserts, c') = self#hoist_lets_out_of_expression c in
+          if Utils.is_empty lets && Utils.is_empty asserts && c == c' && b == b' then (
             Visitor.SkipChildren
           ) else (
-            Visitor.ChangeTo [Stmt_Repeat (b' @ Asl_utils.mk_assigns loc lets, c', pos, loc)]
+            let lets' = Asl_utils.mk_assigns loc lets in
+            let asserts' = Asl_utils.mk_assert_stmts asserts in
+            Visitor.ChangeTo [Stmt_Repeat (b' @ lets' @ asserts', c', pos, loc)]
           )
       | _ ->
           let rebuild (xs : AST.stmt list) : AST.stmt list =
             let loc = Loc.Unknown in
             let lets = bindings in
+            let asserts = checks in
+            let lets' = Asl_utils.mk_assigns loc lets in
+            let asserts' = Asl_utils.mk_assert_stmts asserts in
             bindings <- [];
-            (Asl_utils.mk_assigns loc lets) @ xs
+            checks <- [];
+            lets' @ asserts' @ xs
           in
           Visitor.ChangeDoChildrenPost ([x], rebuild)
       )

--- a/tests/asl_utils_test.ml
+++ b/tests/asl_utils_test.ml
@@ -43,6 +43,7 @@ let test_side_effects (globals : TC.GlobalEnv.t) (prelude : AST.declaration list
     (decls : string) (f : string)
     (expected : (string list * string list * string list * bool))
     () : unit =
+  TC.enable_runtime_checks := false;
   let (tcenv, ds) = extend_tcenv globals decls in
   let ds = prelude @ ds in
   (* to find the definition called 'f', we extract all the declarations called 'f'
@@ -92,6 +93,7 @@ let side_effect_tests : unit Alcotest.test_case list =
  *)
 let test_impure_functions (globals : TC.GlobalEnv.t) (prelude : AST.declaration list)
     (decls : string) (ex_pure : string list) (ex_impure : string list) () : unit =
+  TC.enable_runtime_checks := false;
   let (tcenv, ds) = extend_tcenv globals decls in
   let ds = prelude @ ds in
 
@@ -105,6 +107,7 @@ let test_impure_functions (globals : TC.GlobalEnv.t) (prelude : AST.declaration 
   List.iter (fun f -> if not (in_identSet impure f) then Alcotest.fail ("Function " ^ f ^ " incorrectly marked pure")) ex_impure
 
 let impure_function_tests : unit Alcotest.test_case list =
+  TC.enable_runtime_checks := false;
   let prelude = load_test_libraries () in
   let globals = TC.env0 in
   [

--- a/tests/backends/bits_get_slice_01.asl
+++ b/tests/backends/bits_get_slice_01.asl
@@ -1,0 +1,14 @@
+// RUN: not %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+func FUT_8_4(x : bits(8), i : integer) => bits(4)
+begin
+    return x[i +: 4];
+end
+
+func main() => integer
+begin
+    print_bits_hex(FUT_8_4('1010 0101', 5)); println();
+    // CHECK: Evaluation error: assertion failure
+    return 0;
+end

--- a/tests/backends/bits_get_slice_02.asl
+++ b/tests/backends/bits_get_slice_02.asl
@@ -1,0 +1,14 @@
+// RUN: not %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+func FUT_8_4(x : bits(8), i : integer) => bits(4)
+begin
+    return x[i +: 4];
+end
+
+func main() => integer
+begin
+    print_bits_hex(FUT_8_4('1010 0101', -1)); println();
+    // CHECK: Evaluation error: assertion failure
+    return 0;
+end

--- a/tests/backends/bits_set_slice_01.asl
+++ b/tests/backends/bits_set_slice_01.asl
@@ -1,0 +1,22 @@
+// RUN: %aslrun %s | filecheck %s
+// Copyright (C) 2023-2024 Intel Corporation
+
+func Test(x : bits(4), y : bits(4)) => bits(16)
+begin
+    var result : bits(16);
+    result = asl_zeros_bits(16);
+
+    for i = 0 to 3 do
+        if x[i +: 1] == '1' then
+            result[i * 4 +: 4] = y;
+        end
+    end
+    return result;
+end
+
+func main() => integer
+begin
+    print_bits_hex(Test('1100', '1111')); println();
+    // CHECK: 16'xff00
+    return 0;
+end

--- a/tests/backends/bits_set_slice_02.asl
+++ b/tests/backends/bits_set_slice_02.asl
@@ -1,0 +1,15 @@
+// RUN: not %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+func FUT_8_4(x : bits(8), i : integer, y : bits(4)) => bits(8)
+begin
+    var r = x;
+    r[i +: 4] = y;
+    return r;
+end
+
+func main() => integer
+begin
+    print_bits_hex(FUT_8_4('0000 0000', 5, '1111')); println();
+    // CHECK: Evaluation error: assertion failure
+end

--- a/tests/backends/bits_set_slice_03.asl
+++ b/tests/backends/bits_set_slice_03.asl
@@ -1,0 +1,15 @@
+// RUN: not %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+func FUT_8_4(x : bits(8), i : integer, y : bits(4)) => bits(8)
+begin
+    var r = x;
+    r[i +: 4] = y;
+    return r;
+end
+
+func main() => integer
+begin
+    print_bits_hex(FUT_8_4('0000 0000', -1, '1111')); println();
+    // CHECK: Evaluation error: assertion failure
+end

--- a/tests/backends/expr_assert_00.asl
+++ b/tests/backends/expr_assert_00.asl
@@ -1,0 +1,16 @@
+// RUN: not %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+func FUT(x : bits(8), i : integer) => bit
+begin
+    return __assert 0 <= i && i < 8 __in x[i +: 1];
+end
+
+func main() => integer
+begin
+    // assertion that does fail
+    print_bits_hex(FUT('0000 1111', 9)); println();
+    // CHECK: Evaluation error: assertion failure
+
+    return 0;
+end

--- a/tests/backends/expr_assert_01.asl
+++ b/tests/backends/expr_assert_01.asl
@@ -1,0 +1,20 @@
+// RUN: %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+func FUT(x : bits(8), i : integer) => bit
+begin
+    return __assert 0 <= i && i < 8 __in x[i +: 1];
+end
+
+func main() => integer
+begin
+    // assertion that do not fail
+    print_bits_hex(FUT('1100 1111', 0)); println();
+    // CHECK: 1'x1
+    print_bits_hex(FUT('1100 1111', 4)); println();
+    // CHECK: 1'x0
+    print_bits_hex(FUT('1100 1111', 7)); println();
+    // CHECK: 1'x1
+
+    return 0;
+end

--- a/tests/backends/type_array_00.asl
+++ b/tests/backends/type_array_00.asl
@@ -1,7 +1,7 @@
 // RUN: %aslrun %s | filecheck %s
 // Copyright (C) 2023-2025 Intel Corporation
 
-var R : array [2] of bits(32);
+var R : array [4] of bits(32);
 
 func Test(i : integer) => bits(32)
 begin

--- a/tests/backends/type_array_03.asl
+++ b/tests/backends/type_array_03.asl
@@ -1,0 +1,22 @@
+// RUN: not %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+var R : array [4] of bits(32);
+
+func FUT(i : integer) => bits(32)
+begin
+    return R[i];
+end
+
+func main() => integer
+begin
+    R[0] = 10[0 +: 32];
+    R[1] = 11[0 +: 32];
+    R[2] = 12[0 +: 32];
+    R[3] = 13[0 +: 32];
+
+    print_bits_hex(FUT(4)); println();
+    // CHECK: Evaluation error: assertion failure
+
+    return 0;
+end

--- a/tests/backends/type_array_04.asl
+++ b/tests/backends/type_array_04.asl
@@ -1,0 +1,22 @@
+// RUN: not %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+var R : array [4] of bits(32);
+
+func FUT(i : integer) => bits(32)
+begin
+    return R[i];
+end
+
+func main() => integer
+begin
+    R[0] = 10[0 +: 32];
+    R[1] = 11[0 +: 32];
+    R[2] = 12[0 +: 32];
+    R[3] = 13[0 +: 32];
+
+    print_bits_hex(FUT(-1)); println();
+    // CHECK: Evaluation error: assertion failure
+
+    return 0;
+end

--- a/tests/backends/type_array_05.asl
+++ b/tests/backends/type_array_05.asl
@@ -1,0 +1,17 @@
+// RUN: not %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+var R : array [3] of bits(32);
+
+func FUT(i : integer, x : bits(32))
+begin
+    R[i] = x;
+end
+
+func main() => integer
+begin
+    FUT(4, asl_zeros_bits(32));
+    // CHECK: Evaluation error: assertion failure
+
+    return 0;
+end

--- a/tests/backends/type_array_06.asl
+++ b/tests/backends/type_array_06.asl
@@ -1,0 +1,17 @@
+// RUN: not %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+var R : array [3] of bits(32);
+
+func FUT(i : integer, x : bits(32))
+begin
+    R[i] = x;
+end
+
+func main() => integer
+begin
+    FUT(-1, asl_zeros_bits(32));
+    // CHECK: Evaluation error: assertion failure
+
+    return 0;
+end

--- a/tests/lit/runtime_checks/array_read_00.asl
+++ b/tests/lit/runtime_checks/array_read_00.asl
@@ -1,0 +1,10 @@
+// RUN: %asli --batchmode --exec=":show --format=raw FUT*" %s | filecheck %s
+// Copyright (C) 2025-2025 Intel Corporation
+
+var R : array [16] of bits(32);
+
+func FUT1(i : integer {0..15}) => bits(32)
+begin
+    return R[i];
+    // CHECK: __assert asl_lt_int.0{}(i, 16) __in __assert asl_le_int.0{}(0, i) __in R[i];
+end

--- a/tests/lit/runtime_checks/array_write_00.asl
+++ b/tests/lit/runtime_checks/array_write_00.asl
@@ -1,0 +1,11 @@
+// RUN: %asli --batchmode --exec=":show --format=raw FUT*" %s | filecheck %s
+// Copyright (C) 2025-2025 Intel Corporation
+
+var R : array [16] of bits(32);
+
+func FUT1(i : integer {0..15}, val : bits(32))
+begin
+    R[i] = val;
+    // CHECK: assert asl_lt_int.0{}(i, 16);
+    // CHECK: assert asl_le_int.0{}(0, i);
+end

--- a/tests/lit/runtime_checks/bits_read_00.asl
+++ b/tests/lit/runtime_checks/bits_read_00.asl
@@ -1,0 +1,27 @@
+// RUN: %asli --batchmode --exec=":show --format=raw FUT*" %s | filecheck %s
+// Copyright (C) 2025-2025 Intel Corporation
+
+func FUT1(x : bits(32), i : integer {0..31}) => bits(1)
+begin
+    return x[i];
+    // CHECK: return __assert asl_lt_int.0{}(i, 32) __in __assert asl_le_int.0{}(0, i) __in {bits(32)}x[i];
+end
+
+func FUT2(x : bits(32), h : integer {0..31}, l : integer {0..4}) => bits(h-l+1)
+begin
+    return x[h : l];
+    // CHECK: return __assert asl_lt_int.0{}(h, 32) __in __assert asl_le_int.0{}(l, h) __in __assert asl_le_int.0{}(0, l) __in {bits(32)}x[h : l];
+end
+
+
+func FUT3(x : bits(32), j : integer {0..15}, w : integer) => bits(w)
+begin
+    return x[j +: w];
+    // CHECK: return __assert asl_le_int.0{}(asl_add_int.0{}(j, w), 32) __in __assert asl_le_int.0{}(0, w) __in __assert asl_le_int.0{}(0, j) __in {bits(32)}x[j +: w];
+end
+
+func FUT4(x : bits(32), j : integer {0..8}, w : integer) => bits(w)
+begin
+    return x[j *: w];
+    // CHECK: return __assert asl_le_int.0{}(asl_mul_int.0{}(j, w), asl_sub_int.0{}(32, w)) __in __assert asl_le_int.0{}(0, w) __in __assert asl_le_int.0{}(0, j) __in {bits(32)}x[j *: w];
+end

--- a/tests/lit/runtime_checks/bits_write_00.asl
+++ b/tests/lit/runtime_checks/bits_write_00.asl
@@ -1,0 +1,42 @@
+// RUN: %asli --batchmode --exec=":show --format=raw FUT*" %s | filecheck %s
+// Copyright (C) 2025-2025 Intel Corporation
+
+func FUT1(x : bits(32), i : integer {0..31}) => bits(32)
+begin
+    var r : bits(32) = x;
+    r[i] = Ones(1);
+    // CHECK: assert asl_lt_int.0{}(i, 32);
+    // CHECK: assert asl_le_int.0{}(0, i);
+    return r;
+end
+
+func FUT2(x : bits(32), h : integer {0..31}, l : integer {0..4}) => bits(32)
+begin
+    var r : bits(32) = x;
+    r[h:l] = Ones(h-l+1);
+    // CHECK: assert asl_lt_int.0{}(h, 32);
+    // CHECK: assert asl_le_int.0{}(l, h);
+    // CHECK: assert asl_le_int.0{}(0, l);
+    return r;
+end
+
+
+func FUT3(x : bits(32), j : integer {0..15}, w : integer) => bits(32)
+begin
+    var r : bits(32) = x;
+    r[j+:w] = Ones(w);
+    // CHECK: assert asl_le_int.0{}(asl_add_int.0{}(j, w), 32);
+    // CHECK: assert asl_le_int.0{}(0, w);
+    // CHECK: assert asl_le_int.0{}(0, j);
+    return r;
+end
+
+func FUT4(x : bits(32), j : integer {0..8}, w : integer) => bits(32)
+begin
+    var r : bits(32) = x;
+    r[j*:w] = Ones(w);
+    // CHECK: assert asl_le_int.0{}(asl_mul_int.0{}(j, w), asl_sub_int.0{}(32, w));
+    // CHECK: assert asl_le_int.0{}(0, w);
+    // CHECK: assert asl_le_int.0{}(0, j);
+    return r;
+end

--- a/tests/lit/runtime_checks/conversion_00.asl
+++ b/tests/lit/runtime_checks/conversion_00.asl
@@ -1,0 +1,16 @@
+// RUN: %asli --batchmode --exec=":show --format=raw FUT*" %s | filecheck %s
+// Copyright (C) 2025-2025 Intel Corporation
+
+func FUT1(i : integer {0..15}) => integer {0..7, 15}
+begin
+    let r = if i < 8 then i else 15;
+    return (r as {0..7, 15});
+    // CHECK: return __assert asl_or_bool.0{}(asl_and_bool.0{}(asl_le_int.0{}(0, r), asl_le_int.0{}(r, 7)), asl_eq_int.0{}(r, 15)) __in r as {0..7, 15};
+end
+
+func FUT2(i : integer {0..15}) => integer {0..7, 15}
+begin
+    let r = if i < 8 then i else 15;
+    return (r as integer {0..7, 15});
+    // CHECK: return __assert asl_or_bool.0{}(asl_and_bool.0{}(asl_le_int.0{}(0, r), asl_le_int.0{}(r, 7)), asl_eq_int.0{}(r, 15)) __in r as integer{0..7, 15};
+end

--- a/tests/lit/runtime_checks/int_divide_00.asl
+++ b/tests/lit/runtime_checks/int_divide_00.asl
@@ -1,0 +1,26 @@
+// RUN: %asli --batchmode --exec=":show --format=raw FUT*" %s | filecheck %s
+// Copyright (C) 2025-2025 Intel Corporation
+
+func FUT1(x : integer, y : integer) => integer
+begin
+    return x DIV y;
+    // CHECK: __assert asl_ne_int.0{}(0, y) __in asl_exact_div_int.0{}(x, y);
+end
+
+func FUT2(x : integer, y : integer) => integer
+begin
+    return x MOD y;
+    // CHECK: __assert asl_ne_int.0{}(0, y) __in asl_frem_int.0{}(x, y);
+end
+
+func FUT3(x : integer, y : integer) => integer
+begin
+    return x QUOT y;
+    // CHECK: __assert asl_ne_int.0{}(0, y) __in asl_zdiv_int.0{}(x, y);
+end
+
+func FUT4(x : integer, y : integer) => integer
+begin
+    return x REM y;
+    // CHECK: __assert asl_ne_int.0{}(0, y) __in asl_zrem_int.0{}(x, y);
+end

--- a/tests/lit/xform_hoist_lets/test_02.asl
+++ b/tests/lit/xform_hoist_lets/test_02.asl
@@ -1,0 +1,19 @@
+// RUN: %asli --batchmode --exec=:xform_hoist_lets --exec=":show --format=raw FUT" %s | filecheck %s
+// Copyright (C) 2025-2025 Intel Corporation
+
+func FUT(x : bits(32), i : integer {0..32}) => boolean
+begin
+    // A variant of the original motivating example that prevented use
+    // of a transformation that looked for "IsZero(x[_ +: _])"
+    return IsZero(__let wd : integer = 32-i __in
+                  __let ix : integer = 31-i __in
+                  __assert 0 <= ix && ix < 32 __in
+                  __assert 0 <= wd && ix + wd <= 32 __in
+                  x[ix +: wd]);
+end
+
+// CHECK: let wd : integer = asl_sub_int.0{}(32, i);
+// CHECK: let ix : integer = asl_sub_int.0{}(31, i);
+// CHECK: assert asl_and_bool.0{}(asl_le_int.0{}(0, ix), asl_lt_int.0{}(ix, 32));
+// CHECK: assert asl_and_bool.0{}(asl_le_int.0{}(0, wd), asl_le_int.0{}(asl_add_int.0{}(ix, wd), 32));
+// CHECK: return IsZero.0{wd}({bits(32)}x[ix +: wd]);

--- a/tests/lit/xform_hoist_lets/test_03.asl
+++ b/tests/lit/xform_hoist_lets/test_03.asl
@@ -1,4 +1,4 @@
-// RUN: %asli --batchmode --exec=:xform_hoist_lets --exec=":show --format=raw FUT" %s | filecheck %s
+// RUN: %asli --batchmode --noruntime-checks --exec=:xform_hoist_lets --exec=":show --format=raw FUT" %s | filecheck %s
 // Copyright (C) 2025-2025 Intel Corporation
 
 func FUT(i : integer) => boolean

--- a/tests/lit/xform_hoist_lets/test_03.asl
+++ b/tests/lit/xform_hoist_lets/test_03.asl
@@ -1,0 +1,57 @@
+// RUN: %asli --batchmode --exec=:xform_hoist_lets --exec=":show --format=raw FUT" %s | filecheck %s
+// Copyright (C) 2025-2025 Intel Corporation
+
+func FUT(i : integer) => boolean
+begin
+    // Check that asserts are not lifted past sequencing points
+    // AND
+    let r1 = i >= 0 && (__assert i MOD 2 == 1 __in i <= 10);
+    // CHECK:       asl_and_bool.0{}(asl_ge_int.0{}(i, 0), __assert asl_eq_int.0{}(asl_frem_int.0{}(i, 2), 1) __in asl_le_int.0{}(i, 10));
+    let r2 = i >= 0 && i <= (__assert i MOD 2 == 1 __in 10);
+    // CHECK:       asl_and_bool.0{}(asl_ge_int.0{}(i, 0), __assert asl_eq_int.0{}(asl_frem_int.0{}(i, 2), 1) __in asl_le_int.0{}(i, 10));
+
+    // OR
+    let r3 = i >= 0 || i <= (__assert i MOD 2 == 1 __in 10);
+    // CHECK:       asl_or_bool.0{}(asl_ge_int.0{}(i, 0), __assert asl_eq_int.0{}(asl_frem_int.0{}(i, 2), 1) __in asl_le_int.0{}(i, 10));
+
+    // IMPLIES
+    let r4 = i >= 0 --> i <= (__assert i MOD 2 == 1 __in 10);
+    // CHECK:       asl_implies_bool.0{}(asl_ge_int.0{}(i, 0), __assert asl_eq_int.0{}(asl_frem_int.0{}(i, 2), 1) __in asl_le_int.0{}(i, 10));
+
+    // IF expression
+    let r5 = if i >= 0 then i <= (__assert i MOD 2 == 1 __in 10) else FALSE;
+    // CHECK:       if asl_ge_int.0{}(i, 0) then __assert asl_eq_int.0{}(asl_frem_int.0{}(i, 2), 1) __in asl_le_int.0{}(i, 10) else FALSE;
+
+    // IF statement
+    if __let b1 : boolean = i >= 0 __in b1 then
+        let r6 = i <= (__assert i MOD 2 == 1 __in 10);
+    else
+        let r7 = i <= (__assert i MOD 2 == 1 __in 10);
+    end
+    // CHECK:       let b1 : boolean = asl_ge_int.0{}(i, 0);
+    // CHECK-NEXT:  if b1 then
+    // CHECK-NEXT:      assert asl_eq_int.0{}(asl_frem_int.0{}(i, 2), 1);
+    // CHECK-NEXT:      let r6 : boolean = asl_le_int.0{}(i, 10);
+    // CHECK-NEXT:  else
+    // CHECK-NEXT:      assert asl_eq_int.0{}(asl_frem_int.0{}(i, 2), 1);
+    // CHECK-NEXT:      let r7 : boolean = asl_le_int.0{}(i, 10);
+    // CHECK-NEXT:  end
+
+    // WHILE loop
+    while i <= (__assert i MOD 2 == 1 __in 10) do
+    end
+    // CHECK:       while __assert asl_eq_int.0{}(asl_frem_int.0{}(i, 2), 1) __in asl_le_int.0{}(i, 10) do
+    // CHECK:       end
+
+    // REPEAT loop
+    repeat
+        let x = 42;
+    until i <= (__assert i MOD 2 == 1 __in 10);
+    // CHECK:       repeat
+    // CHECK-NEXT:      let x : integer{42} = 42;
+    // CHECK-NEXT:      assert asl_eq_int.0{}(asl_frem_int.0{}(i, 2), 1);
+    // CHECK-NEXT:  until asl_le_int.0{}(i, 10);
+
+    return r1 && r2 && r3 && r4 && r5;
+end
+

--- a/tests/xform_bitslices_test.ml
+++ b/tests/xform_bitslices_test.ml
@@ -15,6 +15,7 @@ module TC = Tcheck
  ****************************************************************)
 
 let bitslice_tests : unit Alcotest.test_case list =
+  TC.enable_runtime_checks := false;
   let prelude = load_test_libraries () in
   let globals = TC.env0 in
   let expr = test_xform_expr Xform_bitslices.xform_expr globals prelude in

--- a/tests/xform_bittuples_test.ml
+++ b/tests/xform_bittuples_test.ml
@@ -18,6 +18,7 @@ module TC = Tcheck
 (** Test xform_stmts *)
 let test_bittuple_stmts (globals : TC.GlobalEnv.t) (prelude : AST.declaration list) (decls : string)
     (l : string) (r : string) () : unit =
+  TC.enable_runtime_checks := false;
   let (tcenv, _) = extend_tcenv globals decls in
   let l' = LoadASL.read_stmts tcenv l in
   let r' = LoadASL.read_stmts tcenv r in

--- a/tests/xform_constprop_test.ml
+++ b/tests/xform_constprop_test.ml
@@ -53,6 +53,12 @@ let constprop_tests : unit Alcotest.test_case list =
        "var x : bits(8);" "Replicate(x, 0)" "0'x0");
     ("Replicate(x, 1)", `Quick, test_cp_expr globals prelude
        "var x : bits(8);" "Replicate(x, 1)" "x");
+    ("assert expr dead code", `Quick, test_cp_expr globals prelude
+       "var x : bits(8);" "__assert TRUE __in x" "x");
+    ("assert expr live code 1", `Quick, test_cp_expr globals prelude
+       "var x : bits(8);" "__assert FALSE __in x" "__assert FALSE __in x");
+    ("assert expr live code 2", `Quick, test_cp_expr globals prelude
+       "var x : bits(8);" "__assert IsZero(x) __in x" "__assert IsZero.0(x) __in x");
 
     ("bits(SIZE)", `Quick, test_cp_decls
      "constant SIZE : integer = 32;"

--- a/tests/xform_getset_test.ml
+++ b/tests/xform_getset_test.ml
@@ -15,6 +15,7 @@ module TC = Tcheck
  ****************************************************************)
 
 let getset_tests : unit Alcotest.test_case list =
+  TC.enable_runtime_checks := false;
   let prelude = load_test_libraries () in
   let globals = TC.env0 in
   let decl = test_xform_decls Xform_getset.xform_decls globals prelude in

--- a/tests/xform_int_bitslices_test.ml
+++ b/tests/xform_int_bitslices_test.ml
@@ -15,6 +15,7 @@ module TC = Tcheck
  ****************************************************************)
 
 let int_bitslice_tests : unit Alcotest.test_case list =
+  TC.enable_runtime_checks := false;
   let prelude = load_test_libraries () in
   let globals = TC.env0 in
   let expr = test_xform_expr Xform_int_bitslices.xform_expr globals prelude in

--- a/tests/xform_lower_test.ml
+++ b/tests/xform_lower_test.ml
@@ -15,6 +15,7 @@ module TC = Tcheck
  ****************************************************************)
 
 let bitslices_hilo_tests : unit Alcotest.test_case list =
+  TC.enable_runtime_checks := false;
   let prelude = load_test_libraries () in
   let globals = TC.env0 in
   let expr = test_xform_expr Xform_lower.xform_expr globals prelude in

--- a/tests/xform_tuples_test.ml
+++ b/tests/xform_tuples_test.ml
@@ -16,6 +16,7 @@ module TC = Tcheck
  ****************************************************************)
 
 let tuple_tests : unit Alcotest.test_case list =
+  TC.enable_runtime_checks := false;
   let prelude = load_test_libraries () in
   let globals = TC.env0 in
   let stmts = test_xform_stmts Xform_tuples.xform_stmts globals prelude in

--- a/tests/xform_wrap_test.ml
+++ b/tests/xform_wrap_test.ml
@@ -15,6 +15,7 @@ module TC = Tcheck
  ****************************************************************)
 
 let wrap_tests : unit Alcotest.test_case list =
+  TC.enable_runtime_checks := false;
   let prelude = load_test_libraries () in
   let globals = TC.env0 in
   let decl = test_xform_decls Xform_wrap.xform_decls globals prelude in


### PR DESCRIPTION
Reviewing note: it might be easier to review the first 8 commits individually.
(The first 8 could be a separate PR if you prefer - but their reason for existing is to support the last 3 commits so it makes sense to combine them?)

The first half of this PR

- adds an assert expression "__assert <condition> __in <expression>" for use when inserting runtime checks into expressions
- extends :xform_hoist_lets to hoist assertions in the same way that it hoists expressions
- asl_utils: adds some more utility functions 
- tests: new test and fix for an error in a test that has an accidental runtime error in it
- asl2c: trivial tweak

__assert support is added to all three backends because, even though we are about to deprecate two of the backends, it is important to be able to perform runtime checking in specs that are still using the old backends.

Which is there to support the second part which

- inserts runtime checks into expressions and L-expressions for
  - bitslices
  - array indexing
  - division by zero
- adds lit tests (to confirm that the right checks are inserted)
- adds backend execution tests (to confirm that failing checks do fail)
- fixes up some existing tests by disabling the insertion of runtime checks because the runtime checks were obscuring the original purpose of the tests

Runtime checking can be disabled using --noruntime-checks.
This is intended as a temporary measure while specs fix all their failing runtime checks.