### PR TITLE
Fix exception checks

### DIFF
--- a/bin/asl2c.py
+++ b/bin/asl2c.py
@@ -375,8 +375,10 @@ def generate_c(asli, asl_files, project_file, configurations):
     asli_cmd = [
         asli,
         "--batchmode", "--nobanner",
-        f"--project={project_file}"
     ]
+    asli_cmd.append("--check-call-markers")
+    asli_cmd.append("--check-exception-markers")
+    asli_cmd.append(f"--project={project_file}")
     for file in configurations:
         asli_cmd.append(f"--configuration={file}")
     asli_cmd.extend(asl_files)
@@ -526,9 +528,13 @@ def main() -> int:
         asli_cmd = [
             asli,
             "--batchmode", "--nobanner",
+        ]
+        asli_cmd.append("--check-call-markers")
+        asli_cmd.append("--check-exception-markers")
+        asli_cmd.extend([
             "--exec=let result = main();",
             "--exec=:quit",
-        ]
+        ])
         asli_cmd.extend(args.asl_files)
         run(asli_cmd)
     else:

--- a/libASL/global_checks.ml
+++ b/libASL/global_checks.ml
@@ -29,7 +29,7 @@ let verbose = ref false
 (****************************************************************
  * Check that function definitions have correct throw/nothrow markers
  *
- * This is an experimental extensions where function definitions
+ * This is an experimental extension where function definitions
  * must be marked with whether or not they can throw exceptions
  * and function calls must have a matching marker.
  *
@@ -481,7 +481,7 @@ class rethrow_checks_class (effects : effects_class) (loc : Loc.t) =
                 FMT.varname f
             in
             raise (Error.TypeError (loc, msg))
-        end else
+        end;
         if throws = NoThrow && fthrows then begin
             let msg = Format.asprintf
                 "call to function `%a` should be marked with `?` or `!` because it can throw an exception"
@@ -499,11 +499,12 @@ class rethrow_checks_class (effects : effects_class) (loc : Loc.t) =
         let (_, _, fthrows) = effects#fun_effects f in
         if throws <> NoThrow && not fthrows then begin
             let msg = Format.asprintf
-                "call to procedure `%a` is incorrectly marked with `?`  or `!`but it cannot throw an exception"
+                "call to procedure `%a` is incorrectly marked with `?`  or `!` but it cannot throw an exception"
                 FMT.varname f
             in
             raise (Error.TypeError (loc, msg))
-        end else if throws = NoThrow && fthrows then begin
+        end;
+        if throws = NoThrow && fthrows then begin
             let msg = Format.asprintf
                 "call to procedure `%a` should be marked with `?` or `!` because it can throw an exception"
                 FMT.varname f
@@ -522,16 +523,18 @@ class global_checks_class (effects : effects_class) (markers : (AST.can_throw * 
 
     method! vexpr x =
       ignore (check_expression_order loc effects x);
-      ignore (Asl_visitor.visit_expr (new rethrow_checks_class effects loc) x);
       if !check_call_markers then begin
           ignore (Asl_visitor.visit_expr (new exn_call_checks_class markers loc :> Asl_visitor.aslVisitor) x)
+      end else begin
+          ignore (Asl_visitor.visit_expr (new rethrow_checks_class effects loc) x)
       end;
       SkipChildren
 
     method! vstmt x =
-      ignore (Asl_visitor.visit_stmt (new rethrow_checks_class effects (stmt_loc x)) x);
       if !check_call_markers then begin
           ignore (Asl_visitor.visit_stmt (new exn_call_checks_class markers loc :> Asl_visitor.aslVisitor) x)
+      end else begin
+          ignore (Asl_visitor.visit_stmt (new rethrow_checks_class effects (stmt_loc x)) x)
       end;
       DoChildren
   end

--- a/tests/backends/bits_set_slice_02.asl
+++ b/tests/backends/bits_set_slice_02.asl
@@ -12,4 +12,5 @@ func main() => integer
 begin
     print_bits_hex(FUT_8_4('0000 0000', 5, '1111')); println();
     // CHECK: Evaluation error: assertion failure
+    return 0;
 end

--- a/tests/backends/bits_set_slice_03.asl
+++ b/tests/backends/bits_set_slice_03.asl
@@ -12,4 +12,5 @@ func main() => integer
 begin
     print_bits_hex(FUT_8_4('0000 0000', -1, '1111')); println();
     // CHECK: Evaluation error: assertion failure
+    return 0;
 end

--- a/tests/backends/exceptions_00.asl
+++ b/tests/backends/exceptions_00.asl
@@ -3,7 +3,7 @@
 
 type E of exception;
 
-func Test(x : integer) => integer
+func Test?(x : integer) => integer
 begin
     try
         if x < 0 then

--- a/tests/backends/stmt_try_02.asl
+++ b/tests/backends/stmt_try_02.asl
@@ -21,7 +21,7 @@ begin
     return -1;
 end
 
-func FUT2?(x : integer)
+func FUT2(x : integer)
 begin
     try
         print(FUT?(x)); println();
@@ -42,23 +42,23 @@ end
 
 func main() => integer
 begin
-    FUT2?(0);
+    FUT2(0);
     // CHECK: Caught exception E0
     // CHECK: Exited try block
 
-    FUT2?(1);
+    FUT2(1);
     // CHECK: Caught exception E1{TRUE}
     // CHECK: Exited try block
 
-    FUT2?(2);
+    FUT2(2);
     // CHECK: Caught exception E1{FALSE}
     // CHECK: Exited try block
 
-    FUT2?(3);
+    FUT2(3);
     // CHECK: Caught another exception
     // CHECK: Exited try block
 
-    FUT2?(4);
+    FUT2(4);
     // CHECK: 0x2a
     // CHECK: Did not throw
     // CHECK: Exited try block

--- a/tests/lit/globalchecks/markers_01.asl
+++ b/tests/lit/globalchecks/markers_01.asl
@@ -1,4 +1,4 @@
-// RUN: not %asli --max-errors=10 --check-call-markers --batchmode %s | filecheck %s
+// RUN: not %asli --max-errors=10 --check-exception-markers --check-call-markers --batchmode %s | filecheck %s
 // Copyright (C) 2023-2025 Intel Corporation
 
 type E of exception;
@@ -32,35 +32,35 @@ end
 func F1() => integer
 begin
     let x = NoThrow1?();
-    // CHECK: Type error: call to function `NoThrow1.0` is incorrectly marked with `?` but it cannot throw an exception
+    // CHECK: Type error: Exception marker '?' on call to 'NoThrow1.0' does not match exception marker '' on definition
 end
 
 func F2() => integer
 begin
     NoThrow2!();
-    // CHECK: Type error: call to procedure `NoThrow2.0` is incorrectly marked with `?`  or `!`but it cannot throw an exception
+    // CHECK: Type error: Exception marker '!' on call to 'NoThrow2.0' does not match exception marker '' on definition
 end
 
 func F3() => integer
 begin
     let x = MayThrow1();
-    // CHECK: Type error: call to function `MayThrow1.0` should be marked with `?` or `!` because it can throw an exception
+    // CHECK: Type error: Exception marker '' on call to 'MayThrow1.0' does not match exception marker '?' on definition
 end
 
 func F4() => integer
 begin
     MayThrow2!();
-    // CHECK: Type error: Exception marker '!' on call to 'MayThrow2.0' does not match exception marker '?'
+    // CHECK: Type error: Exception marker '!' on call to 'MayThrow2.0' does not match exception marker '?' on definition
 end
 
 func F5() => integer
 begin
     AlwaysThrow();
-    // CHECK: Type error: call to procedure `AlwaysThrow.0` should be marked with `?` or `!` because it can throw an exception
+    // CHECK: Type error: Exception marker '' on call to 'AlwaysThrow.0' does not match exception marker '!' on definition
 end
 
 func F6() => integer
 begin
     AlwaysThrow?();
-    // CHECK: Type error: Exception marker '?' on call to 'AlwaysThrow.0' does not match exception marker '!'
+    // CHECK: Type error: Exception marker '?' on call to 'AlwaysThrow.0' does not match exception marker '!' on definition
 end


### PR DESCRIPTION
Exception checks were not on by default so there were exception markers were wrong in our tests and the error messages needed improvement.