### PR TITLE
Fix constraint checks

### DIFF
--- a/bin/asl2c.py
+++ b/bin/asl2c.py
@@ -378,6 +378,7 @@ def generate_c(asli, asl_files, project_file, configurations):
     ]
     asli_cmd.append("--check-call-markers")
     asli_cmd.append("--check-exception-markers")
+    asli_cmd.append("--check-constraints")
     asli_cmd.append(f"--project={project_file}")
     for file in configurations:
         asli_cmd.append(f"--configuration={file}")
@@ -531,6 +532,7 @@ def main() -> int:
         ]
         asli_cmd.append("--check-call-markers")
         asli_cmd.append("--check-exception-markers")
+        asli_cmd.append("--check-constraints")
         asli_cmd.extend([
             "--exec=let result = main();",
             "--exec=:quit",

--- a/prelude.asl
+++ b/prelude.asl
@@ -603,7 +603,7 @@ func LowestSetBit(x : bits(N)) => integer {0 .. N}
 begin
     for i = 0 to N-1 do
         if x[i] == '1' then
-            return i;
+            return i as {0..N};
         end
     end
     return N;
@@ -615,7 +615,7 @@ func HighestSetBit(x : bits(N)) => integer {-1 .. N-1}
 begin
     for i = N-1 downto 0 do
         if x[i] == '1' then
-            return i;
+            return i as {0..N-1};
         end
     end
     return -1;

--- a/prelude.asl
+++ b/prelude.asl
@@ -418,7 +418,7 @@ func Log2(a : integer) => integer
 begin
     assert IsPowerOfTwo(a);
     var b = a;
-    var r : integer = 0;
+    var r = 0;
     while b > 1 do
        b = b DIV 2;
        r = r + 1;

--- a/tests/backends/type_ram_00.asl
+++ b/tests/backends/type_ram_00.asl
@@ -17,12 +17,12 @@ end
 
 func Write1(address : bits(8), value : bits(8))
 begin
-    return asl_ram_write(8, 1, __Memory, address, value);
+    asl_ram_write(8, 1, __Memory, address, value);
 end
 
 func Write4(address : bits(8), value : bits(32))
 begin
-    return asl_ram_write(8, 4, __Memory, address, value);
+    asl_ram_write(8, 4, __Memory, address, value);
 end
 
 func main() => integer


### PR DESCRIPTION
Constraint checking was off by default so, naturally, some of our tests had constraint errors in them.
This PR fixes those errors.