### PR TITLE
Add __sint(N) support in backend

### DIFF
--- a/libASL/asl_ast.ml
+++ b/libASL/asl_ast.ml
@@ -156,7 +156,7 @@ and stmt =
  | Stmt_VarDeclsNoInit of Ident.t list * ty * Loc.t
  | Stmt_If of expr * stmt list * s_elsif list * (stmt list * Loc.t) * Loc.t
  | Stmt_Case of expr * ty option * alt list * (stmt list * Loc.t) option * Loc.t
- | Stmt_For of Ident.t * expr * direction * expr * stmt list * Loc.t
+ | Stmt_For of Ident.t * ty * expr * direction * expr * stmt list * Loc.t
  | Stmt_While of expr * stmt list * Loc.t
  | Stmt_Repeat of stmt list * expr * Loc.pos * Loc.t
  | Stmt_Try of stmt list * Loc.pos * catcher list * (stmt list * Loc.t) option * Loc.t

--- a/libASL/asl_fmt.ml
+++ b/libASL/asl_fmt.ml
@@ -754,11 +754,15 @@ let rec stmt (fmt : PP.formatter) (x : AST.stmt) : unit =
                 fmt ob);
           cut fmt;
           kw_end fmt)
-  | Stmt_For (v, f, dir, t, b, loc) ->
+  | Stmt_For (v, typ, f, dir, t, b, loc) ->
       comments_before fmt loc;
       kw_for fmt;
       nbsp fmt;
       varname fmt v;
+      nbsp fmt;
+      colon fmt;
+      nbsp fmt;
+      ty fmt typ;
       nbsp fmt;
       eq fmt;
       nbsp fmt;

--- a/libASL/asl_parser.mly
+++ b/libASL/asl_parser.mly
@@ -478,8 +478,8 @@ apattern:
 | p = expr { Pat_Single(p) }
 
 repetitive_stmt:
-| FOR v = ident EQ f = expr dir = direction t = expr DO b = block END
-    { Stmt_For(v, f, dir, t, b, Range($symbolstartpos, $endpos)) }
+| FOR v = ident ty_opt = ty_opt EQ f = expr dir = direction t = expr DO b = block END
+    { Stmt_For(v, Option.value ty_opt ~default:(Type_Integer(None)), f, dir, t, b, Range($symbolstartpos, $endpos)) }
 | WHILE c = expr DO b = block END
     { Stmt_While(c, b, Range($symbolstartpos, $endpos)) }
 | REPEAT b = block UNTIL c = expr SEMICOLON pos = pos

--- a/libASL/asl_utils.ml
+++ b/libASL/asl_utils.ml
@@ -480,7 +480,7 @@ let stmt_loc (x : AST.stmt) : Loc.t =
   | Stmt_Block (b, loc) -> loc
   | Stmt_If (c, t, els, (e, el), loc) -> loc
   | Stmt_Case (e, oty, alts, ob, loc) -> loc
-  | Stmt_For (v, f, dir, t, b, loc) -> loc
+  | Stmt_For (v, ty, f, dir, t, b, loc) -> loc
   | Stmt_While (c, b, loc) -> loc
   | Stmt_Repeat (b, c, pos, loc) -> loc
   | Stmt_Try (b, pos, cs, ob, loc) -> loc

--- a/libASL/asl_visitor.ml
+++ b/libASL/asl_visitor.ml
@@ -446,13 +446,14 @@ and visit_stmt (vis : aslVisitor) (x : stmt) : stmt list =
         let ob' = mapOptionNoCopy (fun (b, bl) -> (visit_stmts vis b, bl)) ob in
         if e == e' && oty == oty' && alts == alts' && ob == ob' then x
         else Stmt_Case (e', oty', alts', ob', loc)
-    | Stmt_For (v, f, dir, t, b, loc) ->
+    | Stmt_For (v, ty, f, dir, t, b, loc) ->
         let v' = visit_lvar vis v in
+        let ty' = visit_type vis ty in
         let f' = visit_expr vis f in
         let t' = visit_expr vis t in
         let b' = with_locals vis [v] (visit_stmts vis) b in
-        if v == v' && f == f' && t == t' && b == b' then x
-        else Stmt_For (v', f', dir, t', b', loc)
+        if v == v' && ty == ty' && f == f' && t == t' && b == b' then x
+        else Stmt_For (v', ty', f', dir, t', b', loc)
     | Stmt_While (c, b, loc) ->
         let c' = visit_expr vis c in
         let b' = visit_stmts vis b in

--- a/libASL/backend_c.ml
+++ b/libASL/backend_c.ml
@@ -1068,13 +1068,11 @@ let rec stmt (fmt : PP.formatter) (x : AST.stmt) : unit =
   | Stmt_ConstDecl (DeclItem_Wildcard _, i, loc) ->
       make_cast fmt (fun _ -> kw_void fmt) (fun _ -> expr loc fmt i);
       semicolon fmt
-  | Stmt_For (v, f, dir, t, b, loc) ->
+  | Stmt_For (v, ty, f, dir, t, b, loc) ->
       kw_for fmt;
       nbsp fmt;
       parens fmt (fun _ ->
-          kw_asl_int fmt;
-          nbsp fmt;
-          varname fmt v;
+          varty loc fmt v ty;
           nbsp fmt;
           eq fmt;
           nbsp fmt;

--- a/libASL/backend_c_new.ml
+++ b/libASL/backend_c_new.ml
@@ -922,10 +922,9 @@ let rec stmt (fmt : PP.formatter) (x : AST.stmt) : unit =
   | Stmt_ConstDecl (DeclItem_Wildcard _, i, loc) ->
       PP.fprintf fmt "(void)%a;"
         (expr loc) i
-  | Stmt_For (v, f, dir, t, b, loc) ->
-      PP.fprintf fmt  "for (%a %a = %a; %a %s %a; %s%a) {%a@,}"
-          (fun fmt _ -> Runtime.ty_int fmt) ()
-          ident v
+  | Stmt_For (v, ty, f, dir, t, b, loc) ->
+      PP.fprintf fmt  "for (%a = %a; %a %s %a; %s%a) {%a@,}"
+          (fun fmt _ -> varty loc fmt v ty) ()
           (expr loc) f
 
           ident v

--- a/libASL/backend_cpp.ml
+++ b/libASL/backend_cpp.ml
@@ -1227,13 +1227,11 @@ let rec stmt (fmt : PP.formatter) (x : AST.stmt) : unit =
   | Stmt_ConstDecl (DeclItem_Wildcard _, i, loc) ->
       make_cast fmt (fun _ -> kw_void fmt) (fun _ -> expr loc fmt i);
       semicolon fmt
-  | Stmt_For (v, f, dir, t, b, loc) ->
+  | Stmt_For (v, ty, f, dir, t, b, loc) ->
       kw_for fmt;
       nbsp fmt;
       parens fmt (fun _ ->
-          kw_asl_int fmt;
-          nbsp fmt;
-          varname fmt v;
+          varty loc fmt v ty;
           nbsp fmt;
           eq fmt;
           nbsp fmt;

--- a/libASL/eval.ml
+++ b/libASL/eval.ml
@@ -587,7 +587,7 @@ and eval_stmt (env : Env.t) (x : AST.stmt) : unit =
             else eval v alts'
       in
       eval (eval_expr loc env e) alts
-  | Stmt_For (v, start, dir, stop, b, loc) ->
+  | Stmt_For (v, ty, start, dir, stop, b, loc) ->
       let start' = eval_expr loc env start in
       let stop' = eval_expr loc env stop in
       let rec eval i =
@@ -602,8 +602,8 @@ and eval_stmt (env : Env.t) (x : AST.stmt) : unit =
               eval_stmts env' b);
           let i' =
             match dir with
-            | Direction_Up -> eval_add_int loc i (VInt Z.one)
-            | Direction_Down -> eval_sub_int loc i (VInt Z.one)
+            | Direction_Up -> eval_inc loc i
+            | Direction_Down -> eval_dec loc i
           in
           eval i')
       in

--- a/libASL/global_checks.ml
+++ b/libASL/global_checks.ml
@@ -131,7 +131,7 @@ let rec canthrow_stmt (x : AST.stmt) : status =
       let rb = Option.fold ~none:ok ~some:(fun (b, _) -> canthrow_stmts b) ob in
       status_seq r
         (List.fold_left status_merge rb rs)
-  | Stmt_For (v, f, dir, t, b, loc) ->
+  | Stmt_For (v, ty, f, dir, t, b, loc) ->
           (status_seq (canthrow_expr f)
           (status_seq (canthrow_expr t)
                       (canthrow_stmts b)))

--- a/libASL/runtime.ml
+++ b/libASL/runtime.ml
@@ -137,6 +137,8 @@ module type RuntimeLib = sig
   (* convert to/from sint64_t *)
   val ffi_c2asl_integer_small  : PP.formatter -> rt_expr -> unit
   val ffi_asl2c_integer_small  : PP.formatter -> rt_expr -> unit
+  val ffi_c2asl_sintN_small    : PP.formatter -> rt_expr -> unit
+  val ffi_asl2c_sintN_small    : PP.formatter -> rt_expr -> unit
   (* convert to/from uint<N>_t for N in {8, 16, 32, 64} *)
   val ffi_c2asl_bits_small     : int -> PP.formatter -> rt_expr -> unit
   val ffi_asl2c_bits_small     : int -> PP.formatter -> rt_expr -> unit

--- a/libASL/runtime.mli
+++ b/libASL/runtime.mli
@@ -136,6 +136,8 @@ module type RuntimeLib = sig
   (* convert to/from sint64_t *)
   val ffi_c2asl_integer_small  : PP.formatter -> rt_expr -> unit
   val ffi_asl2c_integer_small  : PP.formatter -> rt_expr -> unit
+  val ffi_c2asl_sintN_small    : PP.formatter -> rt_expr -> unit
+  val ffi_asl2c_sintN_small    : PP.formatter -> rt_expr -> unit
   (* convert to/from uint<N>_t for N in {8, 16, 32, 64} *)
   val ffi_c2asl_bits_small     : int -> PP.formatter -> rt_expr -> unit
   val ffi_asl2c_bits_small     : int -> PP.formatter -> rt_expr -> unit

--- a/libASL/runtime_ac.ml
+++ b/libASL/runtime_ac.ml
@@ -375,23 +375,23 @@ module Runtime : RT.RuntimeLib = struct
 
   let get_slice (fmt : PP.formatter) (n : int) (w : int) (l : RT.rt_expr) (i : RT.rt_expr) : unit =
     if w = 1 then
-      PP.fprintf fmt "(%a[%a])"
+      PP.fprintf fmt "(%a[(int)(%a)])"
         RT.pp_expr l
         RT.pp_expr i
     else
-      PP.fprintf fmt "(%a.slc<%d>(%a))"
+      PP.fprintf fmt "(%a.slc<%d>((int)(%a)))"
         RT.pp_expr l
         w
         RT.pp_expr i
 
   let set_slice (fmt : PP.formatter) (n : int) (w : int) (l : RT.rt_expr) (i : RT.rt_expr) (r : RT.rt_expr) : unit =
     if w = 1 then
-      PP.fprintf fmt "%a[%a] = %a;"
+      PP.fprintf fmt "%a[(int)(%a)] = %a;"
         RT.pp_expr l
         RT.pp_expr i
         RT.pp_expr r
     else
-      PP.fprintf fmt "%a.set_slc(%a, %a);"
+      PP.fprintf fmt "%a.set_slc((int)(%a), %a);"
         RT.pp_expr l
         RT.pp_expr i
         RT.pp_expr r

--- a/libASL/runtime_ac.ml
+++ b/libASL/runtime_ac.ml
@@ -590,6 +590,12 @@ module Runtime : RT.RuntimeLib = struct
   let ffi_asl2c_integer_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
     PP.fprintf fmt "%a.to_int64()" RT.pp_expr x
 
+  let ffi_c2asl_sintN_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "((%a)%a)" ty_sint int_width RT.pp_expr x
+
+  let ffi_asl2c_sintN_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "((int64_t)%a)" RT.pp_expr x
+
   let ffi_c2asl_bits_small (n : int) (fmt : PP.formatter) (x : RT.rt_expr) : unit =
     assert (List.mem n [8; 16; 32; 64]);
     PP.fprintf fmt "((%a) %a)"

--- a/libASL/runtime_c23.ml
+++ b/libASL/runtime_c23.ml
@@ -572,6 +572,12 @@ module Runtime : RT.RuntimeLib = struct
   let ffi_asl2c_integer_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
     PP.fprintf fmt "((int64_t)%a)" RT.pp_expr x
 
+  let ffi_c2asl_sintN_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "((%a)%a)" ty_sint int_width RT.pp_expr x
+
+  let ffi_asl2c_sintN_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "((int64_t)%a)" RT.pp_expr x
+
   let ffi_c2asl_bits_small (n : int) (fmt : PP.formatter) (x : RT.rt_expr) : unit =
     assert (List.mem n [8; 16; 32; 64]);
     PP.fprintf fmt "((%a) %a)"

--- a/libASL/runtime_c23.ml
+++ b/libASL/runtime_c23.ml
@@ -383,8 +383,7 @@ module Runtime : RT.RuntimeLib = struct
       RT.pp_expr i
 
   let set_slice (fmt : PP.formatter) (n : int) (w : int) (l : RT.rt_expr) (i : RT.rt_expr) (r : RT.rt_expr) : unit =
-    PP.fprintf fmt "{ %a __index = %a; "
-      ty_uint int_width
+    PP.fprintf fmt "{ __auto_type __index = %a; "
       RT.pp_expr i;
     PP.fprintf fmt "%a __mask = %a >> %d; "
       ty_bits n

--- a/libASL/runtime_fallback.ml
+++ b/libASL/runtime_fallback.ml
@@ -390,6 +390,12 @@ module Runtime : RT.RuntimeLib = struct
   let ffi_asl2c_integer_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
     PP.fprintf fmt "((int64_t)%a)" RT.pp_expr x
 
+  let ffi_c2asl_sintN_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "((%a)%a)" (fun fmt _ -> ty_int fmt) () RT.pp_expr x
+
+  let ffi_asl2c_sintN_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "((int64_t)%a)" RT.pp_expr x
+
   let ffi_c2asl_bits_small (n : int) (fmt : PP.formatter) (x : RT.rt_expr) : unit =
     assert (List.mem n [8; 16; 32; 64]);
     PP.fprintf fmt "((%a) %a)"

--- a/libASL/runtime_sc.ml
+++ b/libASL/runtime_sc.ml
@@ -404,7 +404,7 @@ module Runtime : RT.RuntimeLib = struct
     print_sintN_hexadecimal fmt int_width ~add_size:false x
 
   let get_slice (fmt : PP.formatter) (n : int) (w : int) (l : RT.rt_expr) (i : RT.rt_expr) : unit =
-    PP.fprintf fmt "sc_biguint<%d>(%a.range(%d+%a.to_int()-1,%a.to_int()))"
+    PP.fprintf fmt "sc_biguint<%d>(%a.range(%d+%a-1,%a))"
       w
       RT.pp_expr l
       w
@@ -412,7 +412,7 @@ module Runtime : RT.RuntimeLib = struct
       RT.pp_expr i
 
   let set_slice (fmt : PP.formatter) (n : int) (w : int) (l : RT.rt_expr) (i : RT.rt_expr) (r : RT.rt_expr) : unit =
-    PP.fprintf fmt "%a.range(%d+%a.to_int()-1,%a.to_int()) = %a;"
+    PP.fprintf fmt "%a.range(%d+%a-1,%a) = %a;"
       RT.pp_expr l
       w
       RT.pp_expr i
@@ -624,6 +624,12 @@ module Runtime : RT.RuntimeLib = struct
     PP.fprintf fmt "((%a)%a)" ty_sint int_width RT.pp_expr x
 
   let ffi_asl2c_integer_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "%a.to_int64()" RT.pp_expr x
+
+  let ffi_c2asl_sintN_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "((%a)%a)" ty_sint int_width RT.pp_expr x
+
+  let ffi_asl2c_sintN_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
     PP.fprintf fmt "%a.to_int64()" RT.pp_expr x
 
   let ffi_c2asl_bits_small (n : int) (fmt : PP.formatter) (x : RT.rt_expr) : unit =

--- a/libASL/value.ml
+++ b/libASL/value.ml
@@ -797,6 +797,7 @@ let rec eval_eq (loc : Loc.t) (x : value) (y : value) : bool =
   | VBool x', VBool y' -> prim_eq_bool x' y'
   | VEnum x', VEnum y' -> snd x' = snd y'
   | VInt x', VInt y' -> prim_eq_int x' y'
+  | VIntN x', VIntN y' -> prim_eq_sintN x' y'
   | VReal x', VReal y' -> prim_eq_real x' y'
   | VBits x', VBits y' -> prim_eq_bits x' y'
   | VString x', VString y' -> String.equal x' y'
@@ -811,7 +812,22 @@ let rec eval_eq (loc : Loc.t) (x : value) (y : value) : bool =
 let eval_leq (loc : Loc.t) (x : value) (y : value) : bool =
   match (x, y) with
   | VInt x', VInt y' -> prim_le_int x' y'
-  | _ -> raise (EvalError (loc, "integer expected + string_of_value x"))
+  | VIntN x', VIntN y' -> prim_le_sintN x' y'
+  | _ -> raise (EvalError (loc, "integer or __sint(N) expected " ^ string_of_value x ))
+
+let eval_inc (loc : Loc.t) (x : value) : value =
+  ( match x with
+  | VInt x' -> VInt (prim_add_int x' Z.one)
+  | VIntN x' -> VIntN (prim_add_sintN x' (mksintN x'.n Z.one))
+  | _ -> raise (EvalError (loc, "integer or __sint(N) expected " ^ string_of_value x ))
+  )
+
+let eval_dec (loc : Loc.t) (x : value) : value =
+  ( match x with
+  | VInt x' -> VInt (prim_sub_int x' Z.one)
+  | VIntN x' -> VIntN (prim_sub_sintN x' (mksintN x'.n Z.one))
+  | _ -> raise (EvalError (loc, "integer or __sint(N) expected " ^ string_of_value x ))
+  )
 
 let eval_eq_int (loc : Loc.t) (x : value) (y : value) : bool =
   prim_eq_int (to_integer loc x) (to_integer loc y)

--- a/libASL/value.mli
+++ b/libASL/value.mli
@@ -75,6 +75,8 @@ val insert_bits' : Loc.t -> value -> int -> int -> value -> value
 
 val eval_eq : Loc.t -> value -> value -> bool
 val eval_leq : Loc.t -> value -> value -> bool
+val eval_inc : Loc.t -> value -> value
+val eval_dec : Loc.t -> value -> value
 val eval_eq_int : Loc.t -> value -> value -> bool
 val eval_eq_bits : Loc.t -> value -> value -> bool
 val eval_inmask : Loc.t -> value -> value -> bool

--- a/libASL/xform_constprop.ml
+++ b/libASL/xform_constprop.ml
@@ -561,7 +561,8 @@ and xform_stmt (env : Env.t) (x : AST.stmt) : AST.stmt list =
         )
       | _ -> [ Stmt_Case (e', oty, alts', odefault', loc) ]
       )
-  | Stmt_For (v, start, dir, stop, b, loc) -> (
+  | Stmt_For (v, ty, start, dir, stop, b, loc) -> (
+      let ty' = xform_ty env ty in
       let start' = xform_expr env start in
       let stop' = xform_expr env stop in
       match (value_of_constant env start', value_of_constant env stop') with
@@ -580,8 +581,8 @@ and xform_stmt (env : Env.t) (x : AST.stmt) : AST.stmt list =
               in
               let i' =
                 match dir with
-                | Direction_Up -> Value.eval_add_int loc i Value.int_one
-                | Direction_Down -> Value.eval_sub_int loc i Value.int_one
+                | Direction_Up -> Value.eval_inc loc i
+                | Direction_Down -> Value.eval_dec loc i
               in
               Stmt_Block (b', loc) :: eval i'
             else []
@@ -592,7 +593,7 @@ and xform_stmt (env : Env.t) (x : AST.stmt) : AST.stmt list =
               Env.addLocalVar env' v Values.bottom;
               xform_stmts env' b)
           in
-          [ Stmt_For (v, start', dir, stop', b', loc) ])
+          [ Stmt_For (v, ty', start', dir, stop', b', loc) ])
     | Stmt_While(c, b, loc) ->
           let (c', b') = Env.fixpoint env  (fun env' ->
               let c' = xform_expr env' c in

--- a/tests/backends/ffi_export_01.asl
+++ b/tests/backends/ffi_export_01.asl
@@ -70,6 +70,11 @@ begin
     return x;
 end
 
+func FFI_sint17(x : __sint(17)) => __sint(17)
+begin
+    return x;
+end
+
 // Support for functions that return multiple values
 // is complicated by the fact that the :xform_tuples
 // transformation converts functions that return tuples
@@ -112,6 +117,7 @@ begin
     // CHECK: TRUE
     // CHECK: TRUE
     // CHECK: 42
+    // CHECK: i17'd42
 
     // CHECK: (1, FALSE)
     // CHECK: (4, TRUE)

--- a/tests/backends/ffi_export_01.c
+++ b/tests/backends/ffi_export_01.c
@@ -52,6 +52,7 @@ void FFI_test_exports() {
         printf("%s\n", bret ? "TRUE" : "FALSE");
 
         printf("%d\n", FFI_integer(42));
+        printf("i17'd%d\n", FFI_sint17(42));
 
         int intret2;
         bool boolret2;

--- a/tests/backends/ffi_export_01.json
+++ b/tests/backends/ffi_export_01.json
@@ -16,6 +16,7 @@
         "FFI_E",
         "FFI_boolean",
         "FFI_integer",
+        "FFI_sint17",
         "FFI_int_bool"
     ],
     "imports": [

--- a/tests/backends/ffi_import_01.asl
+++ b/tests/backends/ffi_import_01.asl
@@ -21,6 +21,7 @@ func FFI_null_string(x : string) => string;
 func FFI_null_E(x : E) => E;
 func FFI_null_boolean(x : boolean) => boolean;
 func FFI_null_integer(x : integer) => integer;
+func FFI_null_sint17(x : __sint(17)) => __sint(17);
 
 // Support for functions that return multiple values
 // is complicated by the fact that the :xform_tuples
@@ -69,6 +70,8 @@ begin
     // CHECK: TRUE
     print_int_dec(FFI_null_integer(42)); println();
     // CHECK: 42
+    print_sintN_dec(FFI_null_sint17(i17'd42)); println();
+    // CHECK: i17'd42
 
     let ret1 = FFI_int_bool(1);
     print_int_dec(ret1.r0); print(" "); print(ret1.r1); println();

--- a/tests/backends/ffi_import_01.c
+++ b/tests/backends/ffi_import_01.c
@@ -21,6 +21,7 @@ const char* FFI_null_string(const char *x) { return x; }
 enum E FFI_null_E(enum E x) { return x; }
 bool FFI_null_boolean(bool x) { return x; }
 int FFI_null_integer(int x) { return x; }
+int FFI_null_sint17(int x) { return x; }
 
 void FFI_int_bool(int x, int* ret1, bool* ret2)
 {

--- a/tests/backends/ffi_import_01.json
+++ b/tests/backends/ffi_import_01.json
@@ -18,6 +18,7 @@
         "FFI_null_E",
         "FFI_null_boolean",
         "FFI_null_integer",
+        "FFI_null_sint17",
         "FFI_int_bool"
     ]
 }

--- a/tests/backends/sintN_array_00.asl
+++ b/tests/backends/sintN_array_00.asl
@@ -1,0 +1,29 @@
+// RUN: %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+var R : array [4] of bits(32);
+
+func Test(i : __sint(3)) => bits(32)
+begin
+    return R[asl_cvt_sintN_int(i)];
+end
+
+func main() => integer
+begin
+    R[0] = 10[0 +: 32];
+    R[1] = 11[0 +: 32];
+    R[2] = 12[0 +: 32];
+    R[3] = 13[0 +: 32];
+
+    print_bits_hex(Test(i3'd0)); println();
+    // CHECK: 32'xa
+    print_bits_hex(Test(i3'd1)); println();
+    // CHECK: 32'xb
+    print_bits_hex(Test(i3'd2)); println();
+    // CHECK: 32'xc
+    print_bits_hex(Test(i3'd3)); println();
+    // CHECK: 32'xd
+
+    return 0;
+end
+

--- a/tests/backends/sintN_array_01.asl
+++ b/tests/backends/sintN_array_01.asl
@@ -1,0 +1,29 @@
+// RUN: %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+var R : array [2] of array [2] of bits(32);
+
+func Test(i : __sint(2), j : __sint(2)) => bits(32)
+begin
+    return R[asl_cvt_sintN_int(i)][asl_cvt_sintN_int(j)];
+end
+
+func main() => integer
+begin
+    R[0][0] = 10[0 +: 32];
+    R[0][1] = 11[0 +: 32];
+    R[1][0] = 12[0 +: 32];
+    R[1][1] = 13[0 +: 32];
+
+    print_bits_hex(Test(i2'd0,i2'd0)); println();
+    // CHECK: 32'xa
+    print_bits_hex(Test(i2'd0,i2'd1)); println();
+    // CHECK: 32'xb
+    print_bits_hex(Test(i2'd1,i2'd0)); println();
+    // CHECK: 32'xc
+    print_bits_hex(Test(i2'd1,i2'd1)); println();
+    // CHECK: 32'xd
+
+    return 0;
+end
+

--- a/tests/backends/sintN_array_02.asl
+++ b/tests/backends/sintN_array_02.asl
@@ -1,0 +1,22 @@
+// RUN: %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+let R : array [3] of bits(32) = array(32'x3, 32'x4, 32'x5);
+
+func Test(i : __sint(3)) => bits(32)
+begin
+    return R[asl_cvt_sintN_int(i)];
+end
+
+func main() => integer
+begin
+    print_bits_hex(Test(i3'd0)); println();
+    // CHECK: 32'x3
+    print_bits_hex(Test(i3'd1)); println();
+    // CHECK: 32'x4
+    print_bits_hex(Test(i3'd2)); println();
+    // CHECK: 32'x5
+
+    return 0;
+end
+

--- a/tests/backends/sintN_get_slice_00.asl
+++ b/tests/backends/sintN_get_slice_00.asl
@@ -1,0 +1,23 @@
+// RUN: %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+func Test_8_4(x : bits(8), i : __sint(4)) => bits(4)
+begin
+    return x[asl_cvt_sintN_int(i) +: 4];
+end
+
+func main() => integer
+begin
+    print_bits_hex(Test_8_4('1010 0101', i4'd0)); println();
+    // CHECK: 4'x5
+    print_bits_hex(Test_8_4('1010 0101', i4'd1)); println();
+    // CHECK: 4'x2
+    print_bits_hex(Test_8_4('1010 0101', i4'd2)); println();
+    // CHECK: 4'x9
+    print_bits_hex(Test_8_4('1010 0101', i4'd3)); println();
+    // CHECK: 4'x4
+    print_bits_hex(Test_8_4('1010 0101', i4'd4)); println();
+    // CHECK: 4'xa
+
+    return 0;
+end

--- a/tests/backends/sintN_get_slice_01.asl
+++ b/tests/backends/sintN_get_slice_01.asl
@@ -1,0 +1,22 @@
+// RUN: %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+func FUT(x : bits(4), i : __sint(3)) => bit
+begin
+    return x[asl_cvt_sintN_int(i) +: 1];
+end
+
+func main() => integer
+begin
+    // Positive numbers
+    print_bits_hex(FUT(4'x5, i3'd3)); println();
+    // CHECK: 1'x0
+    print_bits_hex(FUT(4'x5, i3'd2)); println();
+    // CHECK: 1'x1
+    print_bits_hex(FUT(4'x5, i3'd1)); println();
+    // CHECK: 1'x0
+    print_bits_hex(FUT(4'x5, i3'd0)); println();
+    // CHECK: 1'x1
+
+    return 0;
+end

--- a/tests/backends/sintN_set_slice_00.asl
+++ b/tests/backends/sintN_set_slice_00.asl
@@ -1,0 +1,36 @@
+// RUN: %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+func Test_8_4(x : bits(8), i : __sint(4), y : bits(4)) => bits(8)
+begin
+    var r = x;
+    r[asl_cvt_sintN_int(i) +: 4] = y;
+    return r;
+end
+
+func main() => integer
+begin
+    print_bits_hex(Test_8_4('0000 0000', i4'd0, '1111')); println();
+    // CHECK: 8'xf
+    print_bits_hex(Test_8_4('0000 0000', i4'd1, '1111')); println();
+    // CHECK: 8'x1e
+    print_bits_hex(Test_8_4('0000 0000', i4'd2, '1111')); println();
+    // CHECK: 8'x3c
+    print_bits_hex(Test_8_4('0000 0000', i4'd3, '1111')); println();
+    // CHECK: 8'x78
+    print_bits_hex(Test_8_4('0000 0000', i4'd4, '1111')); println();
+    // CHECK: 8'xf0
+
+    print_bits_hex(Test_8_4('1111 1111', i4'd0, '0000')); println();
+    // CHECK: 8'xf0
+    print_bits_hex(Test_8_4('1111 1111', i4'd1, '0000')); println();
+    // CHECK: 8'xe1
+    print_bits_hex(Test_8_4('1111 1111', i4'd2, '0000')); println();
+    // CHECK: 8'xc3
+    print_bits_hex(Test_8_4('1111 1111', i4'd3, '0000')); println();
+    // CHECK: 8'x87
+    print_bits_hex(Test_8_4('1111 1111', i4'd4, '0000')); println();
+    // CHECK: 8'xf
+
+    return 0;
+end

--- a/tests/backends/stmt_for_02.asl
+++ b/tests/backends/stmt_for_02.asl
@@ -1,0 +1,23 @@
+// RUN: %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+func Test(x : __sint(5)) => integer
+begin
+    var s = 0;
+    for i : __sint(5) = i5'd0 to x do
+        s = s + asl_cvt_sintN_int(i);
+    end
+    return s;
+end
+
+func main() => integer
+begin
+    print_int_dec(Test(i5'd0)); println();
+    // CHECK: 0
+    print_int_dec(Test(i5'd1)); println();
+    // CHECK: 1
+    print_int_dec(Test(i5'd3)); println();
+    // CHECK: 6
+
+    return 0;
+end


### PR DESCRIPTION
This adds support for use of __sint(N) when generating code by treating __sint(N) as the preferred choice and use of integer as an unoptimized case that resolves to __sint(N)