### PR TITLE
Add --show-final-asl for testing purposes

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -33,6 +33,7 @@ if proc.returncode == 0 and "1" in proc.stdout:
 
 config.substitutions.append(('%asli', asli_bin_path))
 config.substitutions.append(('%aslrun', f"{asl2c_path} --backend={backend} -O0 --run"))
+config.substitutions.append(('%aslopt', f"{asl2c_path} --show-final-asl"))
 config.environment["ASLI_DIR"] = asl_path
 config.environment["ASL_PATH"] = f":{asl_path}:."
 if ac_types_dir: config.environment["AC_TYPES_DIR"] = ac_types_dir


### PR DESCRIPTION
This adds a new flag --show-final-asl that causes asl2c to print the final ASL code (after all optimizations) to stdout instead of generating C code.
This is intended to support tests that confirm that particular optimizations have been performed.
