### PR TITLE
Fix C23 backend: asl_sub_bits was broken

### DIFF
--- a/libASL/runtime_c23.ml
+++ b/libASL/runtime_c23.ml
@@ -399,7 +399,14 @@ module Runtime : RT.RuntimeLib = struct
   let eq_bits  (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit = binop fmt "==" x y
   let ne_bits  (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit = binop fmt "!=" x y
   let add_bits (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit = binop fmt "+" x y
-  let sub_bits (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit = binop fmt "-" x y
+  let sub_bits (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit =
+    (* Subtraction is awkward because even though the inputs are unsigned, the result seems to be signed
+     * and so we explicitly cast the result back to unsigned.
+     *)
+    PP.fprintf fmt "((%a)(%a - %a))"
+      ty_bits n
+      RT.pp_expr x
+      RT.pp_expr y
   let mul_bits (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit = binop fmt "*" x y
   let and_bits (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit = binop fmt "&" x y
   let or_bits  (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit = binop fmt "|" x y

--- a/tests/backends/bits_sub_01.asl
+++ b/tests/backends/bits_sub_01.asl
@@ -1,0 +1,16 @@
+// RUN: %aslrun %s | filecheck %s
+// Copyright (C) 2025-2025 Intel Corporation
+
+func FUT(x : bits(16)) => bits(64)
+begin
+    // This test used to fail in c23 backend due to the subtraction
+    // being promoted to signed.
+    return asl_zero_extend_bits(asl_sub_bits(x, 16'x1), 64);
+end
+
+func main() => integer
+begin
+    print_bits_hex(FUT(16'x0)); println();
+    // CHECK: 64'xf
+    return 0;
+end


### PR DESCRIPTION
The problem seems to have been due to C integer promotion rules for subtraction.

I could not find part of the standard that described this but both clang and gcc agreed on the result so I ruled out a compiler bug.