### PR TITLE
Index range checks: allow x[31:32]

### DIFF
--- a/libASL/tcheck.ml
+++ b/libASL/tcheck.ml
@@ -975,7 +975,7 @@ let mk_slice_check (loc : Loc.t) (lets : binding list ref) (asserts : check list
           let hi'   = mk_expr_safe_to_replicate lets hi type_integer in
           let lo'   = mk_expr_safe_to_replicate lets lo type_integer in
           add_check loc asserts (mk_le_int zero lo');
-          add_check loc asserts (mk_le_int lo' hi');
+          add_check loc asserts (mk_le_int lo' (mk_add_int hi' one));
           add_check loc asserts (mk_lt_int hi' size');
           Slice_HiLo (hi', lo')
       | Slice_LoWd (lo, wd) ->

--- a/tests/lit/runtime_checks/bits_read_00.asl
+++ b/tests/lit/runtime_checks/bits_read_00.asl
@@ -10,7 +10,7 @@ end
 func FUT2(x : bits(32), h : integer {0..31}, l : integer {0..4}) => bits(h-l+1)
 begin
     return x[h : l];
-    // CHECK: return __assert asl_lt_int.0{}(h, 32) __in __assert asl_le_int.0{}(l, h) __in __assert asl_le_int.0{}(0, l) __in {bits(32)}x[h : l];
+    // CHECK: return __assert asl_lt_int.0{}(h, 32) __in __assert asl_le_int.0{}(l, asl_add_int.0{}(h, 1)) __in __assert asl_le_int.0{}(0, l) __in {bits(32)}x[h : l];
 end
 
 

--- a/tests/lit/runtime_checks/bits_write_00.asl
+++ b/tests/lit/runtime_checks/bits_write_00.asl
@@ -15,7 +15,7 @@ begin
     var r : bits(32) = x;
     r[h:l] = Ones(h-l+1);
     // CHECK: assert asl_lt_int.0{}(h, 32);
-    // CHECK: assert asl_le_int.0{}(l, h);
+    // CHECK: assert asl_le_int.0{}(l, asl_add_int.0{}(h, 1));
     // CHECK: assert asl_le_int.0{}(0, l);
     return r;
 end


### PR DESCRIPTION
This strange looking slice has length zero so it should be legal.

In particular, it is useful in code that wants to zero the top of a register

    x[63:i]

Allowing i to take on any of the values 8, 16, 32 or 64 is useful because it avoids having to treat 64 as a special case.