### PR TITLE
Support fenced code blocks

### DIFF
--- a/libASL/backend_c_new.ml
+++ b/libASL/backend_c_new.ml
@@ -629,9 +629,9 @@ and expr (loc : Loc.t) (fmt : PP.formatter) (x : AST.expr) : unit =
   | Expr_Slices (Type_Bits (n,_), e, [Slice_LoWd (lo, wd)]) ->
       let module Runtime = (val (!runtime) : RuntimeLib) in
       Runtime.get_slice fmt (const_int_expr loc n) (const_int_expr loc wd) (mk_expr loc e) (fun fmt -> index_expr loc fmt lo)
-  | Expr_Slices (Type_Integer _, e, [Slice_LoWd (lo, wd)]) when lo = Asl_utils.zero ->
+  | Expr_Slices (Type_Integer _, e, [Slice_LoWd (lo, wd)]) ->
       let module Runtime = (val (!runtime) : RuntimeLib) in
-      Runtime.cvt_int_bits fmt (const_int_expr loc wd) (mk_expr loc e)
+      Runtime.get_slice_int fmt (const_int_expr loc wd) (mk_expr loc e) (mk_expr loc lo)
   | Expr_TApply (f, tes, es, throws) ->
       if throws <> NoThrow then
         rethrow_expr fmt (fun _ -> funcall loc fmt f tes es)

--- a/libASL/runtime.ml
+++ b/libASL/runtime.ml
@@ -62,6 +62,7 @@ module type RuntimeLib = sig
   val pow2_int : PP.formatter -> rt_expr -> unit
   val align_int : PP.formatter -> rt_expr -> rt_expr -> unit
   val mod_pow2_int : PP.formatter -> rt_expr -> rt_expr -> unit
+  val get_slice_int : PP.formatter -> int -> rt_expr -> rt_expr -> unit
   val set_slice_int : PP.formatter -> int -> rt_expr -> rt_expr -> rt_expr -> unit
   val print_int_dec : PP.formatter -> rt_expr -> unit
   val print_int_hex : PP.formatter -> rt_expr -> unit

--- a/libASL/runtime.mli
+++ b/libASL/runtime.mli
@@ -61,6 +61,7 @@ module type RuntimeLib = sig
   val pow2_int : PP.formatter -> rt_expr -> unit
   val align_int : PP.formatter -> rt_expr -> rt_expr -> unit
   val mod_pow2_int : PP.formatter -> rt_expr -> rt_expr -> unit
+  val get_slice_int : PP.formatter -> int -> rt_expr -> rt_expr -> unit
   val set_slice_int : PP.formatter -> int -> rt_expr -> rt_expr -> rt_expr -> unit
   val print_int_dec : PP.formatter -> rt_expr -> unit
   val print_int_hex : PP.formatter -> rt_expr -> unit

--- a/libASL/runtime_ac.ml
+++ b/libASL/runtime_ac.ml
@@ -367,6 +367,14 @@ module Runtime : RT.RuntimeLib = struct
   let cvt_bits_sint (fmt : PP.formatter) (n : int) (x : RT.rt_expr) : unit = cvt_bits_sint_aux fmt n int_width x
   let cvt_bits_uint (fmt : PP.formatter) (n : int) (x : RT.rt_expr) : unit = cvt_bits_uint_aux fmt n int_width x
 
+  let get_slice_int (fmt : PP.formatter) (w : int) (x : RT.rt_expr) (i : RT.rt_expr) : unit =
+    let mask = Z.sub (Z.shift_left Z.one w) Z.one in
+    PP.fprintf fmt "((%a)((%a >> %a) & %a))"
+      ty_uint w
+      RT.pp_expr x
+      RT.pp_expr i
+      (intN_literal int_width) mask
+
   let set_slice_int (fmt : PP.formatter) (w : int) (l : RT.rt_expr) (i : RT.rt_expr) (r : RT.rt_expr) : unit =
     let mask = Z.sub (Z.shift_left Z.one w) Z.one in
     PP.fprintf fmt "%a = ({ int __index = %a; %a __mask = %a << __index; (%a & ~__mask) | (((%a)%a) << __index); });"

--- a/libASL/runtime_c23.ml
+++ b/libASL/runtime_c23.ml
@@ -385,6 +385,14 @@ module Runtime : RT.RuntimeLib = struct
   let cvt_bits_sint (fmt : PP.formatter) (n : int) (x : RT.rt_expr) : unit = cvt_bits_sint_aux fmt n int_width x
   let cvt_bits_uint (fmt : PP.formatter) (n : int) (x : RT.rt_expr) : unit = cvt_bits_uint_aux fmt n int_width x
 
+  let get_slice_int (fmt : PP.formatter) (w : int) (x : RT.rt_expr) (i : RT.rt_expr) : unit =
+    let mask = Z.sub (Z.shift_left Z.one w) Z.one in
+    PP.fprintf fmt "((%a)((%a >> %a) & %a))"
+      ty_uint w
+      RT.pp_expr x
+      RT.pp_expr i
+      (intN_literal int_width) mask
+
   let set_slice_int (fmt : PP.formatter) (w : int) (l : RT.rt_expr) (i : RT.rt_expr) (r : RT.rt_expr) : unit =
     let mask = Z.sub (Z.shift_left Z.one w) Z.one in
     PP.fprintf fmt "%a = ({ int __index = %a; %a __mask = %a << __index; (%a & ~__mask) | (((%a)%a) << __index); });"

--- a/libASL/runtime_fallback.ml
+++ b/libASL/runtime_fallback.ml
@@ -235,6 +235,14 @@ module Runtime : RT.RuntimeLib = struct
   let cvt_bits_uint (fmt : PP.formatter) (n : int) (x : RT.rt_expr) : unit = apply_bits_1_1 fmt "cvt_bits_uint" n x
   let cvt_int_bits (fmt : PP.formatter) (n : int) (x : RT.rt_expr) : unit = apply_bits_1_1 fmt "cvt_int_bits" n x
 
+  let get_slice_int (fmt : PP.formatter) (w : int) (x : RT.rt_expr) (i : RT.rt_expr) : unit =
+    let slice fmt =
+      PP.fprintf fmt "(%a >> %a)"
+        RT.pp_expr x
+        RT.pp_expr i
+    in
+    cvt_int_bits fmt w slice
+
   let set_slice_int (fmt : PP.formatter) (w : int) (l : RT.rt_expr) (i : RT.rt_expr) (r : RT.rt_expr) : unit =
     let mask = Z.sub (Z.shift_left Z.one w) Z.one in
     PP.fprintf fmt "%a = ({ int __index = %a; %a __mask = %a << __index; (%a & ~__mask) | (((%a)%a) << __index); });"

--- a/libASL/runtime_sc.ml
+++ b/libASL/runtime_sc.ml
@@ -397,6 +397,14 @@ module Runtime : RT.RuntimeLib = struct
   let cvt_bits_sint (fmt : PP.formatter) (n : int) (x : RT.rt_expr) : unit = cvt_bits_sint_aux fmt n int_width x
   let cvt_bits_uint (fmt : PP.formatter) (n : int) (x : RT.rt_expr) : unit = cvt_bits_uint_aux fmt n int_width x
 
+  let get_slice_int (fmt : PP.formatter) (w : int) (x : RT.rt_expr) (i : RT.rt_expr) : unit =
+    let mask = Z.sub (Z.shift_left Z.one w) Z.one in
+    PP.fprintf fmt "((%a)((%a >> %a) & %a))"
+      ty_uint w
+      RT.pp_expr x
+      RT.pp_expr i
+      (intN_literal int_width) mask
+
   let set_slice_int (fmt : PP.formatter) (w : int) (l : RT.rt_expr) (i : RT.rt_expr) (r : RT.rt_expr) : unit =
     let mask = Z.sub (Z.shift_left Z.one w) Z.one in
     PP.fprintf fmt "%a = ({ int __index = %a; %a __mask = %a << __index; (%a & ~__mask) | (((%a)%a) << __index); });"

--- a/tests/lit/parser/fenced_code_block.asl
+++ b/tests/lit/parser/fenced_code_block.asl
@@ -1,0 +1,14 @@
+// RUN: %asli --batchmode %s || filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+```json
+name: main
+shortdesc: Main entrypoint
+longdesc: >
+  Main entrypoint into the specification.
+```
+
+func main() => integer
+begin
+    return 0;
+end


### PR DESCRIPTION
Treat fenced code blocks as comments. This makes it easy to add metadata about a function into the .asl file.

Also, add runtime support for reading integer slices. This was previously handled by a (broken) lowering transformations.