### PR TITLE
Language extension: <expr> with { <changes> }

### DIFF
--- a/libASL/asl_ast.ml
+++ b/libASL/asl_ast.ml
@@ -76,6 +76,7 @@ and expr =
  | Expr_Field of expr * Ident.t (* field selection *)
  | Expr_Fields of expr * Ident.t list (* multiple field selection *)
  | Expr_Slices of ty * expr * slice list (* bitslice *)
+ | Expr_WithChanges of ty * expr * (change * expr) list (* copy with changes *)
  | Expr_RecordInit of Ident.t * expr list * (Ident.t * expr) list
  | Expr_ArrayInit of expr list
  | Expr_In of expr * pattern (* pattern match *)
@@ -88,6 +89,10 @@ and expr =
  | Expr_Concat of expr list * expr list (* bitvector concatenation *)
  | Expr_Array of expr * expr (* array accesses *)
  | Expr_Lit of Value.value
+
+and change =
+ | Change_Field of Ident.t
+ | Change_Slices of slice list
 
 and e_elsif =
    E_Elsif_Cond of expr * expr

--- a/libASL/asl_fmt.ml
+++ b/libASL/asl_fmt.ml
@@ -306,6 +306,15 @@ and slice (fmt : PP.formatter) (x : AST.slice) : unit =
 and slices (fmt : PP.formatter) (ss : AST.slice list) : unit =
   commasep fmt (slice fmt) ss
 
+and changes (fmt : PP.formatter) (cs : (AST.change * AST.expr) list) : unit =
+  commasep fmt (fun (c, e) -> Format.fprintf fmt "%a = %a" change c expr e) cs
+
+and change (fmt : PP.formatter) (x : AST.change) : unit =
+  ( match x with
+  | Change_Field f -> fieldname fmt f
+  | Change_Slices ss -> brackets fmt (fun _ -> slices fmt ss)
+  )
+
 and ixtype (fmt : PP.formatter) (x : AST.ixtype) : unit =
   match x with
   | Index_Enum tc -> tycon fmt tc
@@ -364,6 +373,11 @@ and expr (fmt : PP.formatter) (x : AST.expr) : unit =
       if !show_type_params then braces fmt (fun _ -> ty fmt t);
       expr fmt e;
       brackets fmt (fun _ -> slices fmt ss)
+  | Expr_WithChanges (t, e, cs) ->
+      if !show_type_params then braces fmt (fun _ -> ty fmt t);
+      Format.fprintf fmt "%a with { %a }"
+        expr e
+        changes cs
   | Expr_RecordInit (tc, tes, fas) ->
       tycon fmt tc;
       if not (Utils.is_empty tes) then parens fmt (fun _ -> exprs fmt tes);

--- a/libASL/asl_parser.mly
+++ b/libASL/asl_parser.mly
@@ -108,6 +108,7 @@ let type_unknown = Type_Constructor (Ident.mk_ident "<type_unknown>", [])
 %token ELSIF  (* elsif *)
 %token IN  (* IN *)
 %token UNKNOWN  (* UNKNOWN *)
+%token WITH (* with *)
 
 (* binop tokens *)
 %token AMPERSAND_AMPERSAND  (* && *)
@@ -593,9 +594,15 @@ aexpr:
     { Expr_AsConstraint(e, c) }
 | e = aexpr AS t = ty
     { Expr_AsType(e, t) }
+| e = aexpr WITH LBRACE changes = separated_nonempty_list(COMMA, change) RBRACE
+    { Expr_WithChanges(type_unknown, e, changes) }
 
 field_assignment:
 | ident = ident EQ expr = expr { (ident, expr) }
+
+change:
+| f = ident EQ rhs = expr { (Change_Field f,   rhs) }
+| LBRACK ss = separated_nonempty_list(COMMA, slice) RBRACK EQ rhs = expr { (Change_Slices ss, rhs) }
 
 unop:
 | MINUS { Unop_Negate }

--- a/libASL/asl_visitor.mli
+++ b/libASL/asl_visitor.mli
@@ -27,6 +27,7 @@ class type aslVisitor =
     method vvar : access_kind -> Ident.t -> Ident.t visitAction
     method ve_elsif : e_elsif -> e_elsif visitAction
     method vslice : slice -> slice visitAction
+    method vchange : change -> change visitAction
     method vpattern : pattern -> pattern visitAction
     method vexpr : expr -> expr visitAction
     method vconstraint : constraint_range -> constraint_range visitAction
@@ -47,6 +48,7 @@ val visit_alt : aslVisitor -> alt -> alt
 val visit_arg : aslVisitor -> Ident.t * ty -> Ident.t * ty
 val visit_args : aslVisitor -> (Ident.t * ty) list -> (Ident.t * ty) list
 val visit_catcher : aslVisitor -> catcher -> catcher
+val visit_change : aslVisitor -> change -> change
 val visit_constraint_range : aslVisitor -> constraint_range -> constraint_range
 
 val visit_constraints :

--- a/libASL/backend_c.ml
+++ b/libASL/backend_c.ml
@@ -888,7 +888,9 @@ and expr (loc : Loc.t) (fmt : PP.formatter) (x : AST.expr) : unit =
   | Expr_Slices _
   | Expr_Tuple _
   | Expr_Unknown _
-  | Expr_Unop _ ->
+  | Expr_Unop _
+  | Expr_WithChanges _
+  ->
       raise
         (Error.Unimplemented (loc, "expression", fun fmt -> FMTAST.expr fmt x))
 

--- a/libASL/backend_cpp.ml
+++ b/libASL/backend_cpp.ml
@@ -996,6 +996,7 @@ and expr (loc : Loc.t) (fmt : PP.formatter) (x : AST.expr) : unit =
   | Expr_Slices _
   | Expr_Tuple _
   | Expr_Unknown _
+  | Expr_WithChanges _
   | Expr_Unop _ ->
       raise
         (Error.Unimplemented (loc, "expression", fun fmt -> FMTAST.expr fmt x))

--- a/libASL/lexer.mll
+++ b/libASL/lexer.mll
@@ -69,6 +69,7 @@ let keywords : (string * Asl_parser.token) list = [
     ("when",                   WHEN);
     ("where",                  WHERE);
     ("while",                  WHILE);
+    ("with",                   WITH);
 ]
 
 let update_location lexbuf opt_file line =

--- a/libASL/lexersupport.ml
+++ b/libASL/lexersupport.ml
@@ -112,6 +112,7 @@ let string_of_token (t : Asl_parser.token) : string =
   | WHEN -> "when"
   | WHERE -> "where"
   | WHILE -> "while"
+  | WITH -> "with"
   | XOR -> "xor"
 
 let print_position outx lexbuf =

--- a/tests/backends/expr_with_00.asl
+++ b/tests/backends/expr_with_00.asl
@@ -1,0 +1,14 @@
+// RUN: not %aslrun --runtime-check %s | filecheck %s
+// Copyright (C) 2025-2025 Intel Corporation
+
+func FUT_8_4(x : bits(8), i : integer, y : bits(4)) => bits(8)
+begin
+    return x with { [i +: 4] = y };
+end
+
+func main() => integer
+begin
+    print_bits_hex(FUT_8_4('0000 0000', 5, '1111')); println();
+    // CHECK: Evaluation error: assertion failure
+    return 0;
+end

--- a/tests/backends/expr_with_01.asl
+++ b/tests/backends/expr_with_01.asl
@@ -1,0 +1,34 @@
+// RUN: %aslrun %s | filecheck %s
+// Copyright (C) 2025-2025 Intel Corporation
+
+func Test_8_4(x : bits(8), i : integer, y : bits(4)) => bits(8)
+begin
+    return x with { [i +: 4] = y };
+end
+
+func main() => integer
+begin
+    print_bits_hex(Test_8_4('0000 0000', 0, '1111')); println();
+    // CHECK: 8'xf
+    print_bits_hex(Test_8_4('0000 0000', 1, '1111')); println();
+    // CHECK: 8'x1e
+    print_bits_hex(Test_8_4('0000 0000', 2, '1111')); println();
+    // CHECK: 8'x3c
+    print_bits_hex(Test_8_4('0000 0000', 3, '1111')); println();
+    // CHECK: 8'x78
+    print_bits_hex(Test_8_4('0000 0000', 4, '1111')); println();
+    // CHECK: 8'xf0
+
+    print_bits_hex(Test_8_4('1111 1111', 0, '0000')); println();
+    // CHECK: 8'xf0
+    print_bits_hex(Test_8_4('1111 1111', 1, '0000')); println();
+    // CHECK: 8'xe1
+    print_bits_hex(Test_8_4('1111 1111', 2, '0000')); println();
+    // CHECK: 8'xc3
+    print_bits_hex(Test_8_4('1111 1111', 3, '0000')); println();
+    // CHECK: 8'x87
+    print_bits_hex(Test_8_4('1111 1111', 4, '0000')); println();
+    // CHECK: 8'xf
+
+    return 0;
+end

--- a/tests/backends/expr_with_02.asl
+++ b/tests/backends/expr_with_02.asl
@@ -1,0 +1,21 @@
+// RUN: %aslrun %s | filecheck %s
+// Copyright (C) 2025-2025 Intel Corporation
+
+func Test_8_4(x : bits(8), i : integer, y : bits(4), j : integer, z : bit) => bits(8)
+begin
+    return x with { [i +: 4] = y, [j +: 1] = z };
+end
+
+func main() => integer
+begin
+    print_bits_hex(Test_8_4('0000 0000', 0, '1111', 7, '1')); println();
+    // CHECK: 8'x8f
+
+    print_bits_hex(Test_8_4('0000 0000', 0, '1111', 6, '1')); println();
+    // CHECK: 8'x4f
+
+    print_bits_hex(Test_8_4('0000 0000', 0, '1111', 5, '1')); println();
+    // CHECK: 8'x2f
+
+    return 0;
+end

--- a/tests/backends/expr_with_03.asl
+++ b/tests/backends/expr_with_03.asl
@@ -1,0 +1,41 @@
+// RUN: %aslrun %s | filecheck %s
+// Copyright (C) 2025-2025 Intel Corporation
+
+record R {
+    f0 : bits(4);
+    f1 : boolean;
+};
+
+func FUT1(x : R, y : bits(4)) => R
+begin
+    return x with { f0 = y };
+end
+
+func FUT2(x : R, y : boolean) => R
+begin
+    return x with { f1 = y };
+end
+
+func printR(x : R)
+begin
+    print("R{");
+    print("f0="); print_bits_hex(x.f0);
+    print(", ");
+    print("f1="); print(x.f1);
+    print("}");
+end
+
+func main() => integer
+begin
+    let r = R{f0 = '0000', f1 = FALSE};
+    printR(FUT1(r, '1001')); println();
+    // CHECK: R{f0=4'x9, f1=FALSE}
+
+    printR(FUT1(r, '1011')); println();
+    // CHECK: R{f0=4'xb, f1=FALSE}
+
+    printR(FUT2(r, TRUE)); println();
+    // CHECK: R{f0=4'x0, f1=TRUE}
+
+    return 0;
+end

--- a/tests/lit/runtime_checks/expr_with_00.asl
+++ b/tests/lit/runtime_checks/expr_with_00.asl
@@ -1,0 +1,33 @@
+// RUN: %asli --batchmode --runtime-checks --exec=":show --format=raw FUT*" %s | filecheck %s
+// Copyright (C) 2025-2025 Intel Corporation
+
+func FUT1(x : bits(32), i : integer {0..31}) => bits(32)
+begin
+    return x with { [i] = Ones(1) };
+    // CHECK: return __assert asl_lt_int.0{}(i, 32) __in __assert asl_le_int.0{}(0, i) __in
+end
+
+func FUT2(x : bits(32), h : integer {0..31}, l : integer {0..4}) => bits(32)
+begin
+    return x with { [h:l] = Ones(h-l+1) };
+    // CHECK: return __assert asl_lt_int.0{}(h, 32) __in __assert asl_le_int.0{}(l, asl_add_int.0{}(h, 1)) __in __assert asl_le_int.0{}(0, l) __in
+end
+
+
+func FUT3(x : bits(32), j : integer {0..15}, w : integer) => bits(32)
+begin
+    return x with { [j+:w] = Ones(w) };
+    // CHECK: return __assert asl_le_int.0{}(asl_add_int.0{}(j, w), 32) __in __assert asl_le_int.0{}(0, w) __in __assert asl_le_int.0{}(0, j) __in
+end
+
+func FUT4(x : bits(32), j : integer {0..8}, w : integer) => bits(32)
+begin
+    return x with { [j*:w] = Ones(w) };
+    // CHECK: return __assert asl_le_int.0{}(asl_mul_int.0{}(j, w), asl_sub_int.0{}(32, w)) __in __assert asl_le_int.0{}(0, w) __in __assert asl_le_int.0{}(0, j) __in
+end
+
+func FUT5(x : bits(32), j : integer {0..15}, w : integer) => bits(32)
+begin
+    return x with { [j-:w] = Ones(w) };
+    // CHECK: return __assert asl_le_int.0{}(w, asl_add_int.0{}(j, 1)) __in __assert asl_le_int.0{}(0, w) __in __assert asl_lt_int.0{}(j, 32) __in
+end


### PR DESCRIPTION
This adds a simpler way to make a copy of a bitvector or record and change some fields in the process.

Instead of

    var y = x;
    y[0] = '1';
    ... y ...

You can write

    ... (x with { [0] = '1' }) ...

I believe that this will be quite useful.

Implements #62