### PR TITLE
Language extension: Print

### DIFF
--- a/libASL/builtin_idents.ml
+++ b/libASL/builtin_idents.ml
@@ -164,6 +164,9 @@ let print_char        = Ident.mk_fident "print_char"
 let print_str         = Ident.mk_fident "print_str"
 let print_bits_hex    = Ident.mk_fident "print_bits_hex"
 let print_bits        = Ident.mk_fident "print_bits"
+let print_boolean     = Ident.mk_fident "asl_print_bool"
+
+let print             = Ident.mk_fident "Print"
 
 (* Other identifiers *)
 let boolean_ident   = Ident.mk_ident "boolean"

--- a/libASL/builtin_idents.mli
+++ b/libASL/builtin_idents.mli
@@ -170,6 +170,8 @@ val cvt_int_sintN    : Ident.t
 val resize_sintN     : Ident.t
 val print_sintN_dec  : Ident.t
 val print_sintN_hex  : Ident.t
+val print            : Ident.t
+val print_boolean    : Ident.t
 
 (****************************************************************
  * End

--- a/prelude.asl
+++ b/prelude.asl
@@ -680,13 +680,18 @@ begin
     print_str(x);
 end
 
-func print(x : boolean)
+func asl_print_bool(x : boolean)
 begin
     if x then
         print("TRUE");
     else
         print("FALSE");
     end
+end
+
+func print(x : boolean)
+begin
+    asl_print_bool(x);
 end
 
 func print(x : integer)
@@ -698,6 +703,8 @@ func println()
 begin
     print_char(10);
 end
+
+__builtin func Print(x : string) => ();
 
 // Convert an integer to a decimal string, prefixing with '-' if negative.
 func DecStr(x : integer) => string

--- a/tests/lit/print/print_00.asl
+++ b/tests/lit/print/print_00.asl
@@ -1,0 +1,19 @@
+// RUN: %asli --batchmode --runtime-checks --exec=":show --format=raw FUT*" %s | filecheck %s
+// Copyright (C) 2025-2025 Intel Corporation
+
+func FUT1(x : bits(4), y : integer, z : string, b : boolean)
+begin
+    Print("x={x} y={y} z={z} b={b}");
+end
+
+// CHECK:      func FUT1.0{}(x : bits(4), y : integer, z : string, b : boolean)
+// CHECK_NEXT: begin
+// CHECK_NEXT:     print_str.0("x=");
+// CHECK_NEXT:     print_bits_hex.0(x);
+// CHECK_NEXT:     print_str.0(" y=");
+// CHECK_NEXT:     print_int_dec.0(y);
+// CHECK_NEXT:     print_str.0(" z=");
+// CHECK_NEXT:     print_str.0(z);
+// CHECK_NEXT:     print_str.0(" b=");
+// CHECK_NEXT:     asl_print_bool.0(b);
+// CHECK_NEXT: end


### PR DESCRIPTION
This adds a polymorphic print function inspired by Python f-strings.

e.g., 'Print(x={x}n);' prints 'x=3\n' (if x = 3).

At the moment, formatting is limited to just printing the value with no format control and the types of variables printed is limited to bitvector, integer, string or boolean.

The plan is to support user-defined types and control over decimal/hex, etc. based on a subset of Python f-strings.