### PR TITLE
SC backend: optimize representation of small integers

### DIFF
--- a/libASL/backend_c_new.ml
+++ b/libASL/backend_c_new.ml
@@ -720,8 +720,8 @@ and exprs (loc : Loc.t) (fmt : PP.formatter) (es : AST.expr list) : unit =
 and index_expr (loc : Loc.t) (fmt : PP.formatter) (x : AST.expr) : unit =
   let module Runtime = (val (!runtime) : RuntimeLib) in
   ( match x with
-  | Expr_TApply (f, _, [x'], _) when Ident.equal f cvt_sintN_int ->
-      Runtime.ffi_asl2c_sintN_small fmt (mk_expr loc x')
+  | Expr_TApply (f, [n], [x'], _) when Ident.equal f cvt_sintN_int ->
+      Runtime.ffi_asl2c_sintN_small (const_int_expr loc n) fmt (mk_expr loc x')
   | _ ->
       Runtime.ffi_asl2c_integer_small fmt (mk_expr loc x)
   )
@@ -1454,11 +1454,11 @@ let mk_ffi_conversion (loc : Loc.t) (indirect : bool) (c_name : Ident.t) (asl_na
           PP.fprintf fmt "%a%a = %a;"
             ptr ()
             ident c_name
-            Runtime.ffi_asl2c_sintN_small pp_asl_name);
+            (Runtime.ffi_asl2c_sintN_small (Z.to_int n)) pp_asl_name);
         pp_c_to_asl = (fun fmt ->
           varty loc fmt asl_name asl_type;
           PP.fprintf fmt " = %a;"
-            Runtime.ffi_c2asl_sintN_small pp_c_name);
+            (Runtime.ffi_c2asl_sintN_small (Z.to_int n)) pp_c_name);
       }
   | Type_Bits(Expr_Lit (VInt n), _)
     when List.mem (Z.to_int n) [8; 16; 32; 64]

--- a/libASL/runtime.ml
+++ b/libASL/runtime.ml
@@ -141,8 +141,8 @@ module type RuntimeLib = sig
   (* convert to/from sint64_t *)
   val ffi_c2asl_integer_small  : PP.formatter -> rt_expr -> unit
   val ffi_asl2c_integer_small  : PP.formatter -> rt_expr -> unit
-  val ffi_c2asl_sintN_small    : PP.formatter -> rt_expr -> unit
-  val ffi_asl2c_sintN_small    : PP.formatter -> rt_expr -> unit
+  val ffi_c2asl_sintN_small    : int -> PP.formatter -> rt_expr -> unit
+  val ffi_asl2c_sintN_small    : int -> PP.formatter -> rt_expr -> unit
   (* convert to/from uint<N>_t for N in {8, 16, 32, 64} *)
   val ffi_c2asl_bits_small     : int -> PP.formatter -> rt_expr -> unit
   val ffi_asl2c_bits_small     : int -> PP.formatter -> rt_expr -> unit

--- a/libASL/runtime.mli
+++ b/libASL/runtime.mli
@@ -140,8 +140,8 @@ module type RuntimeLib = sig
   (* convert to/from sint64_t *)
   val ffi_c2asl_integer_small  : PP.formatter -> rt_expr -> unit
   val ffi_asl2c_integer_small  : PP.formatter -> rt_expr -> unit
-  val ffi_c2asl_sintN_small    : PP.formatter -> rt_expr -> unit
-  val ffi_asl2c_sintN_small    : PP.formatter -> rt_expr -> unit
+  val ffi_c2asl_sintN_small    : int -> PP.formatter -> rt_expr -> unit
+  val ffi_asl2c_sintN_small    : int -> PP.formatter -> rt_expr -> unit
   (* convert to/from uint<N>_t for N in {8, 16, 32, 64} *)
   val ffi_c2asl_bits_small     : int -> PP.formatter -> rt_expr -> unit
   val ffi_asl2c_bits_small     : int -> PP.formatter -> rt_expr -> unit

--- a/libASL/runtime_ac.ml
+++ b/libASL/runtime_ac.ml
@@ -623,10 +623,10 @@ module Runtime : RT.RuntimeLib = struct
   let ffi_asl2c_integer_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
     PP.fprintf fmt "%a.to_int64()" RT.pp_expr x
 
-  let ffi_c2asl_sintN_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+  let ffi_c2asl_sintN_small (n : int) (fmt : PP.formatter) (x : RT.rt_expr) : unit =
     PP.fprintf fmt "((%a)%a)" ty_sint int_width RT.pp_expr x
 
-  let ffi_asl2c_sintN_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+  let ffi_asl2c_sintN_small (n : int) (fmt : PP.formatter) (x : RT.rt_expr) : unit =
     PP.fprintf fmt "((int64_t)%a)" RT.pp_expr x
 
   let ffi_c2asl_bits_small (n : int) (fmt : PP.formatter) (x : RT.rt_expr) : unit =

--- a/libASL/runtime_c23.ml
+++ b/libASL/runtime_c23.ml
@@ -625,10 +625,10 @@ module Runtime : RT.RuntimeLib = struct
   let ffi_asl2c_integer_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
     PP.fprintf fmt "((int64_t)%a)" RT.pp_expr x
 
-  let ffi_c2asl_sintN_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+  let ffi_c2asl_sintN_small (n : int) (fmt : PP.formatter) (x : RT.rt_expr) : unit =
     PP.fprintf fmt "((%a)%a)" ty_sint int_width RT.pp_expr x
 
-  let ffi_asl2c_sintN_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+  let ffi_asl2c_sintN_small (n : int) (fmt : PP.formatter) (x : RT.rt_expr) : unit =
     PP.fprintf fmt "((int64_t)%a)" RT.pp_expr x
 
   let ffi_c2asl_bits_small (n : int) (fmt : PP.formatter) (x : RT.rt_expr) : unit =

--- a/libASL/runtime_c23.ml
+++ b/libASL/runtime_c23.ml
@@ -626,7 +626,7 @@ module Runtime : RT.RuntimeLib = struct
     PP.fprintf fmt "((int64_t)%a)" RT.pp_expr x
 
   let ffi_c2asl_sintN_small (n : int) (fmt : PP.formatter) (x : RT.rt_expr) : unit =
-    PP.fprintf fmt "((%a)%a)" ty_sint int_width RT.pp_expr x
+    PP.fprintf fmt "((%a)%a)" ty_sint n RT.pp_expr x
 
   let ffi_asl2c_sintN_small (n : int) (fmt : PP.formatter) (x : RT.rt_expr) : unit =
     PP.fprintf fmt "((int64_t)%a)" RT.pp_expr x

--- a/libASL/runtime_fallback.ml
+++ b/libASL/runtime_fallback.ml
@@ -412,10 +412,10 @@ module Runtime : RT.RuntimeLib = struct
   let ffi_asl2c_integer_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
     PP.fprintf fmt "((int64_t)%a)" RT.pp_expr x
 
-  let ffi_c2asl_sintN_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+  let ffi_c2asl_sintN_small (n : int) (fmt : PP.formatter) (x : RT.rt_expr) : unit =
     PP.fprintf fmt "((%a)%a)" (fun fmt _ -> ty_int fmt) () RT.pp_expr x
 
-  let ffi_asl2c_sintN_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+  let ffi_asl2c_sintN_small (n : int) (fmt : PP.formatter) (x : RT.rt_expr) : unit =
     PP.fprintf fmt "((int64_t)%a)" RT.pp_expr x
 
   let ffi_c2asl_bits_small (n : int) (fmt : PP.formatter) (x : RT.rt_expr) : unit =

--- a/libASL/runtime_sc.ml
+++ b/libASL/runtime_sc.ml
@@ -50,8 +50,22 @@ module Runtime : RT.RuntimeLib = struct
       "#include \"asl/runtime.hpp\"";
   ]
 
-  let ty_int (fmt : PP.formatter) : unit = ty_sint fmt int_width
-  let ty_sintN (fmt : PP.formatter) (width : int) : unit = ty_sint fmt width
+  (* round up integer sizes to 8/16/32/64 *)
+  let nearest_intsize (width : int) : int =
+      if width <= 8 then 8
+      else if width <= 16 then 16
+      else if width <= 32 then 32
+      else if width <= 64 then 64
+      else failwith "nearest_intsize: called with bad argument"
+
+  let ty_sintN (fmt : PP.formatter) (width : int) : unit =
+      (* Optimization: use standard types when we can *)
+      if width <= 64 then
+          PP.fprintf fmt "int%d_t" (nearest_intsize width)
+      else
+          ty_sint fmt width
+
+  let ty_int (fmt : PP.formatter) : unit = ty_sintN fmt int_width
   let ty_bits (fmt : PP.formatter) (width : int) : unit = ty_uint fmt width
   let ty_ram (fmt : PP.formatter) : unit = asl_keyword fmt "ram_t"
 
@@ -79,7 +93,9 @@ module Runtime : RT.RuntimeLib = struct
     PP.fprintf fmt "})"
 
   let intN_literal (n : int) (fmt : PP.formatter) (x : Z.t) : unit =
-    if Z.gt x min_64bit_signed && Z.leq x max_64bit_signed then begin
+    if n <= 64 then
+      PP.fprintf fmt "(%s)" (Z.format "%d" x)
+    else if Z.gt x min_64bit_signed && Z.leq x max_64bit_signed then begin
       (* Minor optimization to improve readability and efficiency *)
       PP.fprintf fmt "sc_bigint<%d>(%s)" n (Z.format "%d" x)
     end else if Z.geq x Z.zero then begin
@@ -120,16 +136,16 @@ module Runtime : RT.RuntimeLib = struct
     else if Z.equal x.v (Z.of_int32_unsigned Int32.minus_one) then begin
       PP.fprintf fmt "UINT32_MAX"
     end else if x.n <= 64 && Z.leq x.v (Z.of_int64_unsigned Int64.minus_one) then begin
-      PP.fprintf fmt "sc_biguint<%d>(%sULL)" x.n (Z.format "%#x" x.v)
+      PP.fprintf fmt "%a(%sULL)" ty_bits x.n (Z.format "%#x" x.v)
     end else if x.n <= 32 then begin
-      Format.fprintf fmt "sc_biguint<%d>(%a)"
-        x.n
+      Format.fprintf fmt "%a(%a)"
+        ty_bits x.n
         constant_u32 x.v
     end else begin
       let num_limbs = (x.n + 31) / 32 in
       let limbs = split_int x.v num_limbs 32 in
       PP.fprintf fmt "asl::sc_bit_fill<%a,%d>((int [%d]){"
-        ty_uint x.n
+        ty_bits x.n
         x.n
         num_limbs;
       PP.pp_print_list
@@ -171,13 +187,13 @@ module Runtime : RT.RuntimeLib = struct
 
   let fdiv_sintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit =
     PP.fprintf fmt "({ %a __tmp1 = %a; "
-      ty_sint n
+      ty_sintN n
       RT.pp_expr x;
     PP.fprintf fmt "%a __tmp2 = %a; "
-      ty_sint n
+      ty_sintN n
       RT.pp_expr y;
-    PP.fprintf fmt "%a __tmp3 = __tmp1 / __tmp2; " ty_sint n;
-    PP.fprintf fmt "%a __tmp4 = __tmp1 %% __tmp2; " ty_sint n;
+    PP.fprintf fmt "%a __tmp3 = __tmp1 / __tmp2; " ty_sintN n;
+    PP.fprintf fmt "%a __tmp4 = __tmp1 %% __tmp2; " ty_sintN n;
     PP.fprintf fmt "if (__tmp4 != 0 && (__tmp1 < %a || __tmp2 < %a)) { __tmp3 = __tmp3 - 1; } "
       zero_sintN n
       zero_sintN n;
@@ -185,13 +201,13 @@ module Runtime : RT.RuntimeLib = struct
 
   let frem_sintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit =
     PP.fprintf fmt "({ %a __tmp1 = %a; "
-      ty_sint n
+      ty_sintN n
       RT.pp_expr x;
     PP.fprintf fmt "%a __tmp2 = %a; "
-      ty_sint n
+      ty_sintN n
       RT.pp_expr y;
-    PP.fprintf fmt "%a __tmp3 = __tmp1 / __tmp2; " ty_sint n;
-    PP.fprintf fmt "%a __tmp4 = __tmp1 %% __tmp2; " ty_sint n;
+    PP.fprintf fmt "%a __tmp3 = __tmp1 / __tmp2; " ty_sintN n;
+    PP.fprintf fmt "%a __tmp4 = __tmp1 %% __tmp2; " ty_sintN n;
     PP.fprintf fmt "if (__tmp4 != 0 && (__tmp1 < %a || __tmp2 < %a)) { __tmp4 = __tmp4 + __tmp2; } "
       zero_sintN n
       zero_sintN n;
@@ -199,30 +215,30 @@ module Runtime : RT.RuntimeLib = struct
 
   let is_pow2_sintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) : unit =
     PP.fprintf fmt "({ %a __tmp = %a; "
-      ty_sint n
+      ty_sintN n
       RT.pp_expr x;
     PP.fprintf fmt "__tmp != 0 && (__tmp & (__tmp - 1)) == 0; })"
 
   let pow2_sintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) : unit =
     PP.fprintf fmt "(%a << %a)"
-      int_literal Z.one
+      (intN_literal n) Z.one
       RT.pp_expr x
 
   let align_sintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit =
     (* x & (~((1 << y) - 1)) *)
     PP.fprintf fmt "(%a & (~((%a << %a) - %a)))"
       RT.pp_expr x
-      int_literal Z.one
+      (intN_literal n) Z.one
       RT.pp_expr y
-      int_literal Z.one
+      (intN_literal n) Z.one
 
   let mod_pow2_sintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit =
     (* x & ((1 << y) - 1) *)
     PP.fprintf fmt "(%a & ((%a << %a) - %a))"
       RT.pp_expr x
-      int_literal Z.one
+      (intN_literal n) Z.one
       RT.pp_expr y
-      int_literal Z.one
+      (intN_literal n) Z.one
 
   (* A generalization of cvt_bits_ssintN that can either
    * - convert bits(N) to __sint(N)
@@ -242,10 +258,18 @@ module Runtime : RT.RuntimeLib = struct
         (intN_literal target_width) Z.one
         (intN_literal target_width) Z.zero
     end else begin
-      PP.fprintf fmt "((%a)((%a)%a))"
-        ty_sint target_width
-        ty_sint n
-        RT.pp_expr x
+      if target_width <= 64 then begin
+        PP.fprintf fmt "((%a)((%a.to_int64() << %d) >> %d))"
+          ty_sintN target_width
+          RT.pp_expr x
+          (64-n)
+          (64-n)
+      end else begin
+        PP.fprintf fmt "((%a)((%a)%a))"
+          ty_sintN target_width
+          ty_sint n
+          RT.pp_expr x
+      end
     end
 
   let cvt_bits_ssintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) : unit = cvt_bits_sint_aux fmt n n x
@@ -260,12 +284,17 @@ module Runtime : RT.RuntimeLib = struct
       (* Although we return zero, we may still need to execute 'x' for any side effects *)
       PP.fprintf fmt "({ (void)%a; %a; })"
         RT.pp_expr x
-        int_literal Z.zero
+        (intN_literal n) Z.zero
     end else begin
-      PP.fprintf fmt "((%a)((%a)%a))"
-        ty_sint target_width
-        ty_uint target_width
-        RT.pp_expr x
+      if target_width <= 64 then
+        PP.fprintf fmt "((%a)(%a.to_uint64()))"
+          ty_sintN target_width
+          RT.pp_expr x
+      else
+        PP.fprintf fmt "((%a)((%a)%a))"
+          ty_sintN target_width
+          ty_bits target_width
+          RT.pp_expr x
     end
 
   let cvt_bits_usintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) : unit = cvt_bits_uint_aux fmt n (n+1) x
@@ -276,27 +305,57 @@ module Runtime : RT.RuntimeLib = struct
       PP.fprintf fmt "({ (void)%a; %a; })"
         RT.pp_expr x
         empty_bits ()
+    else if n <= 64 then
+      PP.fprintf fmt "(%a(%a))"
+        ty_bits n
+        RT.pp_expr x
     else
       PP.fprintf fmt "((%a)(%a))"
-        ty_uint n
+        ty_bits n
         RT.pp_expr x
 
   let cvt_sintN_int (fmt : PP.formatter) (n : int) (x : RT.rt_expr) : unit =
-    PP.fprintf fmt "((%a)%a)"
-      ty_sint int_width
-      RT.pp_expr x
+    if n <= 64 then
+      PP.fprintf fmt "(%a(%a))"
+        ty_sintN int_width
+        RT.pp_expr x
+    else
+      PP.fprintf fmt "((%a)%a)"
+        ty_sintN int_width
+        RT.pp_expr x
 
   let cvt_int_sintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) : unit =
-    PP.fprintf fmt "((%a)%a)"
-      ty_sint n
-      RT.pp_expr x
+    if n <= 64 then
+      PP.fprintf fmt "((%a)%a.to_int64())"
+        ty_sintN n
+        RT.pp_expr x
+    else
+      PP.fprintf fmt "((%a)%a)"
+        ty_sintN n
+        RT.pp_expr x
 
   let resize_sintN (fmt : PP.formatter) (m : int) (n : int) (x : RT.rt_expr) : unit =
-    PP.fprintf fmt "((%a)%a)"
-      ty_sint n
-      RT.pp_expr x
+    if m <= 64 then begin
+      if n <= 64 then
+        PP.fprintf fmt "((%a)%a)"
+          ty_sintN n
+          RT.pp_expr x
+      else
+        PP.fprintf fmt "(%a(%a))"
+          ty_sintN n
+          RT.pp_expr x
+    end else begin
+      if n <= 64 then
+        PP.fprintf fmt "((%a)%a.to_int64())"
+          ty_sintN n
+          RT.pp_expr x
+      else
+        PP.fprintf fmt "((%a)%a)"
+          ty_sintN n
+          RT.pp_expr x
+    end
 
-  let print_sint64_decimal (fmt : PP.formatter) (n : int) (add_size : bool) (x : string) : unit =
+  let print_sint64_decimal_small (fmt : PP.formatter) (n : int) (add_size : bool) (x : string) : unit =
     if add_size then begin
       PP.fprintf fmt "    if (%s == %a) {@," x (pp_min_sintN n) n;
       PP.fprintf fmt "      printf(\"-i%d'd%s\");@," n (Z.to_string (Z.shift_left Z.one (n - 1)));
@@ -305,49 +364,53 @@ module Runtime : RT.RuntimeLib = struct
       PP.fprintf fmt "        %s = -%s;@," x x;
       PP.fprintf fmt "        printf(\"-\");@,";
       PP.fprintf fmt "      }@,";
-      PP.fprintf fmt "      printf(\"i%d'd%%llu\", %s.to_uint64());@," n x;
+      PP.fprintf fmt "      printf(\"i%d'd%%lu\", (uint64_t)(%s));@," n x;
       PP.fprintf fmt "    }"
     end else begin
-      PP.fprintf fmt "    printf(\"%%lld\", %s.to_uint64());@," x
+      PP.fprintf fmt "    printf(\"%%ld\", (uint64_t)(%s));@," x
     end
 
   let print_sintN_decimal (fmt : PP.formatter) (n : int) ~(add_size : bool) (x : RT.rt_expr) : unit =
-    if n <= 64 then begin
-        PP.fprintf fmt "@[<v>{ %a __tmp = %a;@," ty_sint n RT.pp_expr x;
-        print_sint64_decimal fmt n add_size "__tmp";
-        PP.fprintf fmt "}@]"
-    end else begin
-        (* Print small numbers in decimal, large numbers in hex *)
-        PP.fprintf fmt "@[<v>{ %a __tmp = %a;@," ty_sint n RT.pp_expr x;
-        PP.fprintf fmt "  if (__tmp >= %a && __tmp <= %a) {@,"
-          (pp_min_sintN n) 63
-          (pp_max_sintN n) 63;
-        print_sint64_decimal fmt n add_size "__tmp";
-        PP.fprintf fmt "  } else {@,";
-        PP.fprintf fmt "    if (__tmp < %a) {@," zero_sintN n;
-        PP.fprintf fmt "      __tmp = -__tmp;@,";
-        PP.fprintf fmt "      printf(\"-\");@,";
-        PP.fprintf fmt "    }@,";
-        (if add_size then PP.fprintf fmt "    printf(\"%d'x\");@," n
-                     else PP.fprintf fmt "    printf(\"0x\");@,");
-        PP.fprintf fmt "    bool leading = true;@,";
-        PP.fprintf fmt "    for(int i = (%d-1)&~3; i >= 0; i -= 4) {@," n;
-        PP.fprintf fmt "      unsigned c = sc_uint<4>(__tmp.range(3+i,i)).to_uint() & 15;@,";
-        PP.fprintf fmt "      if (leading) {@,";
-        PP.fprintf fmt "        if (i == 0 || c) {@,";
-        PP.fprintf fmt "          printf(\"%%x\", c);@,";
-        PP.fprintf fmt "          leading = false;@,";
-        PP.fprintf fmt "        }@,";
-        PP.fprintf fmt "      } else {@,";
-        PP.fprintf fmt "        printf(\"%%x\", c);@,";
-        PP.fprintf fmt "      }@,";
-        PP.fprintf fmt "    }@,";
-        PP.fprintf fmt "  }@,";
-        PP.fprintf fmt "}@]"
-    end
+    (* Print small numbers in decimal, large numbers in hex *)
+    PP.fprintf fmt "@[<v>{ %a __tmp = %a;@," ty_sintN n RT.pp_expr x;
+    PP.fprintf fmt "  if (__tmp >= %a && __tmp <= %a) {@,"
+      (pp_min_sintN n) 63
+      (pp_max_sintN n) 63;
+    begin
+      if n <= 64 then
+        print_sint64_decimal_small fmt n add_size "__tmp"
+      else
+        print_sint64_decimal_small fmt n add_size "__tmp.to_int()"
+    end;
+    PP.fprintf fmt "  } else {@,";
+    PP.fprintf fmt "    if (__tmp < %a) {@," zero_sintN n;
+    PP.fprintf fmt "      __tmp = -__tmp;@,";
+    PP.fprintf fmt "      printf(\"-\");@,";
+    PP.fprintf fmt "    }@,";
+    (if add_size then PP.fprintf fmt "    printf(\"%d'x\");@," n
+                 else PP.fprintf fmt "    printf(\"0x\");@,");
+    PP.fprintf fmt "    bool leading = true;@,";
+    PP.fprintf fmt "    for(int i = (%d-1)&~3; i >= 0; i -= 4) {@," n;
+    begin
+      if n <= 64 then
+        PP.fprintf fmt "    unsigned c = (__tmp >> i) & 0xf;@,"
+      else
+        PP.fprintf fmt "    unsigned c = sc_uint<4>(__tmp.range(3+i,i)).to_uint();@,"
+    end;
+    PP.fprintf fmt "      if (leading) {@,";
+    PP.fprintf fmt "        if (i == 0 || c) {@,";
+    PP.fprintf fmt "          printf(\"%%x\", c);@,";
+    PP.fprintf fmt "          leading = false;@,";
+    PP.fprintf fmt "        }@,";
+    PP.fprintf fmt "      } else {@,";
+    PP.fprintf fmt "        printf(\"%%x\", c);@,";
+    PP.fprintf fmt "      }@,";
+    PP.fprintf fmt "    }@,";
+    PP.fprintf fmt "  }@,";
+    PP.fprintf fmt "}@]"
 
   let print_sintN_hexadecimal (fmt : PP.formatter) (n : int) ~(add_size : bool) (x : RT.rt_expr) : unit =
-    PP.fprintf fmt "@[<v>{ %a __tmp = %a;@," ty_sint n RT.pp_expr x;
+    PP.fprintf fmt "@[<v>{ %a __tmp = %a;@," ty_sintN n RT.pp_expr x;
     PP.fprintf fmt "  if (__tmp < %a) {@," zero_sintN n;
     PP.fprintf fmt "    __tmp = -__tmp;@,";
     PP.fprintf fmt "    printf(\"-\");@,";
@@ -356,7 +419,12 @@ module Runtime : RT.RuntimeLib = struct
                  else PP.fprintf fmt "  printf(\"0x\");@,");
     PP.fprintf fmt "  bool leading = true;@,";
     PP.fprintf fmt "  for(int i = (%d-1)&~3; i >= 0; i -= 4) {@," n;
-    PP.fprintf fmt "    unsigned c = sc_uint<4>(__tmp.range(3+i,i)).to_uint();@,";
+    begin
+      if n <= 64 then
+        PP.fprintf fmt "    unsigned c = (__tmp >> i) & 0xf;@,"
+      else
+        PP.fprintf fmt "    unsigned c = sc_uint<4>(__tmp.range(3+i,i)).to_uint();@,"
+    end;
     PP.fprintf fmt "    if (leading) {@,";
     PP.fprintf fmt "      if (i == 0 || c) {@,";
     PP.fprintf fmt "        printf(\"%%x\", c);@,";
@@ -373,7 +441,6 @@ module Runtime : RT.RuntimeLib = struct
 
   let print_sintN_hex (fmt : PP.formatter) (n : int) (x : RT.rt_expr) : unit =
     print_sintN_hexadecimal fmt n ~add_size:true x
-
 
   (* signed unbounded integers *)
 
@@ -405,7 +472,7 @@ module Runtime : RT.RuntimeLib = struct
   let get_slice_int (fmt : PP.formatter) (w : int) (x : RT.rt_expr) (i : RT.rt_expr) : unit =
     let mask = Z.sub (Z.shift_left Z.one w) Z.one in
     PP.fprintf fmt "((%a)((%a >> %a) & %a))"
-      ty_uint w
+      ty_bits w
       RT.pp_expr x
       RT.pp_expr i
       (intN_literal int_width) mask
@@ -415,10 +482,10 @@ module Runtime : RT.RuntimeLib = struct
     PP.fprintf fmt "%a = ({ int __index = %a; %a __mask = %a << __index; (%a & ~__mask) | (((%a)%a) << __index); });"
       RT.pp_expr l
       RT.pp_expr i
-      ty_sint int_width
+      ty_sintN int_width
       (intN_literal int_width) mask
       RT.pp_expr l
-      ty_sint int_width
+      ty_sintN int_width
       RT.pp_expr r
 
   let print_int_dec (fmt : PP.formatter) (x : RT.rt_expr) : unit =
@@ -466,7 +533,7 @@ module Runtime : RT.RuntimeLib = struct
 
   let asr_bits (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit =
     PP.fprintf fmt "((%a)(((%a)%a) >> %a))"
-      ty_uint n
+      ty_bits n
       ty_sint n
       RT.pp_expr x
       RT.pp_expr y
@@ -501,12 +568,12 @@ module Runtime : RT.RuntimeLib = struct
 
   let zero_extend_bits (fmt : PP.formatter) (m : int) (n : int)  (x : RT.rt_expr) : unit =
     PP.fprintf fmt "((%a)%a)"
-    ty_uint n
+    ty_bits n
     RT.pp_expr x
 
   let sign_extend_bits (fmt : PP.formatter) (m : int) (n : int)  (x : RT.rt_expr) : unit =
     PP.fprintf fmt "((%a)(%a)(%a)%a)"
-    ty_uint n
+    ty_bits n
     ty_sint n
     ty_sint m
     RT.pp_expr x
@@ -648,20 +715,20 @@ module Runtime : RT.RuntimeLib = struct
 
   (* Foreign Function Interface (FFI) *)
   let ffi_c2asl_integer_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
-    PP.fprintf fmt "((%a)%a)" ty_sint int_width RT.pp_expr x
+    PP.fprintf fmt "((%a)%a)" ty_sintN int_width RT.pp_expr x
 
   let ffi_asl2c_integer_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
     PP.fprintf fmt "%a.to_int64()" RT.pp_expr x
 
-  let ffi_c2asl_sintN_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
-    PP.fprintf fmt "((%a)%a)" ty_sint int_width RT.pp_expr x
+  let ffi_c2asl_sintN_small (n : int) (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "((%a)%a)" ty_sintN n RT.pp_expr x
 
-  let ffi_asl2c_sintN_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
-    PP.fprintf fmt "%a.to_int64()" RT.pp_expr x
+  let ffi_asl2c_sintN_small (n : int) (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "((%a)%a)" ty_sintN 64 RT.pp_expr x
 
   let ffi_c2asl_bits_small (n : int) (fmt : PP.formatter) (x : RT.rt_expr) : unit =
     assert (List.mem n [8; 16; 32; 64]);
-    PP.fprintf fmt "((%a) %a)"
+    PP.fprintf fmt "((%a)%a)"
       ty_bits n
       RT.pp_expr x
 
@@ -678,7 +745,7 @@ module Runtime : RT.RuntimeLib = struct
       RT.pp_expr x;
     PP.fprintf fmt "%a = asl::sc_bit_fill<%a,%d>((const int [%d]){"
       RT.pp_expr x
-      ty_uint n
+      ty_bits n
       n
       num_limbs;
     for limb = 0 to num_limbs - 1 do


### PR DESCRIPTION
Use int{8,16,32,64}_t when we can.