### PR TITLE
Cleanup: procedure returns unit

### DIFF
--- a/libASL/asl_ast.ml
+++ b/libASL/asl_ast.ml
@@ -155,9 +155,8 @@ and stmt =
  | Stmt_VarDecl of decl_item * expr * Loc.t
  | Stmt_ConstDecl of decl_item * expr * Loc.t
  | Stmt_Assign of lexpr * expr * Loc.t
- | Stmt_FunReturn of expr * Loc.t (* function return *)
- | Stmt_ProcReturn of Loc.t (* procedure return *)
- | Stmt_Assert of expr * Loc.t (* assertion *)
+ | Stmt_Return of expr * Loc.t
+ | Stmt_Assert of expr * Loc.t
  | Stmt_Throw of expr * Loc.t
  | Stmt_UCall of Ident.t * (Ident.t option * expr) list * can_throw * Loc.t (* procedure call before typechecking - optional name arguments, no type parameters *)
  | Stmt_TCall of Ident.t * expr list * expr list * can_throw * Loc.t (* procedure call with explicit type parameters *)
@@ -179,7 +178,7 @@ type function_type = {
   parameters : (Ident.t * ty option) list;
   args : (Ident.t * ty * expr option) list;
   setter_arg : (Ident.t * ty) option; (* only present in setter functions *)
-  rty : ty option; (* only present in functions and getter functions *)
+  rty : ty;
   use_array_syntax : bool; (* true for array getter/setter functions *)
   is_getter_setter : bool;
   throws : can_throw;

--- a/libASL/asl_fmt.ml
+++ b/libASL/asl_fmt.ml
@@ -615,14 +615,8 @@ let rec stmt ?(short=false) (fmt : PP.formatter) (x : AST.stmt) : unit =
       throws fmt can_throw;
       parens fmt (fun _ -> pp_args fmt args);
       semicolon fmt;
-  | Stmt_FunReturn (e, loc) ->
-      kw_return fmt;
-      nbsp fmt;
-      expr fmt e;
-      semicolon fmt
-  | Stmt_ProcReturn loc ->
-      kw_return fmt;
-      semicolon fmt
+  | Stmt_Return (e, loc) ->
+      PP.fprintf fmt "return %a;" expr e
   | Stmt_Assert (e, loc) ->
       kw_assert fmt;
       nbsp fmt;
@@ -787,13 +781,7 @@ let function_type (fmt : PP.formatter) (fty : AST.function_type) : unit =
       nbsp fmt;
       varty fmt v ty)
     fmt fty.setter_arg;
-  PP.pp_print_option
-    (fun _ rty ->
-      nbsp fmt;
-      eq_gt fmt;
-      nbsp fmt;
-      ty fmt rty)
-    fmt fty.rty
+  Format.fprintf fmt " => %a" ty fty.rty
 
 let declaration ?(short=false) (fmt : PP.formatter) (x : AST.declaration) : unit =
   vbox fmt (fun _ ->

--- a/libASL/asl_parser.mly
+++ b/libASL/asl_parser.mly
@@ -9,6 +9,7 @@
 %{
 open Asl_ast
 open Loc
+module Asl_utils = Asl_utils
 
 (* The following type is used in the parser in places where
  * the typechecker is expected to insert an inferred type that is
@@ -245,21 +246,21 @@ throws:
 
 function_declaration:
 | UNDERSCORE_UNDERSCORE_BUILTIN FUNC f = ident throws=throws ps = parameters_opt LPAREN args = formals_with_default RPAREN EQ_GT ty = ty SEMICOLON
-    { let fty = { parameters=ps; args; setter_arg=None; rty=Some ty; use_array_syntax=false; is_getter_setter=false; throws } in
+    { let fty = { parameters=ps; args; setter_arg=None; rty=ty; use_array_syntax=false; is_getter_setter=false; throws } in
       Decl_BuiltinFunction(f, fty, Range($symbolstartpos, $endpos)) }
 | FUNC f = ident throws=throws ps = parameters_opt LPAREN args = formals_with_default RPAREN EQ_GT ty = ty SEMICOLON
-    { let fty = { parameters=ps; args; setter_arg=None; rty=Some ty; use_array_syntax=false; is_getter_setter=false; throws } in
+    { let fty = { parameters=ps; args; setter_arg=None; rty=ty; use_array_syntax=false; is_getter_setter=false; throws } in
       Decl_FunType(f, fty, Range($symbolstartpos, $endpos)) }
 | FUNC f = ident throws=throws ps = parameters_opt LPAREN args = formals_with_default RPAREN EQ_GT ty = ty BEGIN b = block END
-    { let fty = { parameters=ps; args; setter_arg=None; rty=Some ty; use_array_syntax=false; is_getter_setter=false; throws } in
+    { let fty = { parameters=ps; args; setter_arg=None; rty=ty; use_array_syntax=false; is_getter_setter=false; throws } in
       Decl_FunDefn(f, fty, b, Range($symbolstartpos, $endpos)) }
 
 procedure_declaration:
 | FUNC f = ident throws=throws ps = parameters_opt LPAREN args = formals_with_default RPAREN SEMICOLON
-    { let fty = { parameters=ps; args; setter_arg=None; rty=None; use_array_syntax=false; is_getter_setter=false; throws } in
+    { let fty = { parameters=ps; args; setter_arg=None; rty=Asl_utils.type_unit; use_array_syntax=false; is_getter_setter=false; throws } in
       Decl_FunType(f, fty, Range($symbolstartpos, $endpos)) }
 | FUNC f = ident throws=throws ps = parameters_opt LPAREN args = formals_with_default RPAREN BEGIN b = block END
-    { let fty = { parameters=ps; args; setter_arg=None; rty=None; use_array_syntax=false; is_getter_setter=false; throws } in
+    { let fty = { parameters=ps; args; setter_arg=None; rty=Asl_utils.type_unit; use_array_syntax=false; is_getter_setter=false; throws } in
       Decl_FunDefn(f, fty, b, Range($symbolstartpos, $endpos)) }
 
 parameters_opt:
@@ -291,30 +292,30 @@ formal:
 
 getter_declaration:
 | GETTER f = ident throws=throws ps = parameters_opt EQ_GT ty = ty SEMICOLON
-    { let fty = { parameters=ps; args=[]; setter_arg=None; rty=Some ty; use_array_syntax=false; is_getter_setter=true; throws } in
+    { let fty = { parameters=ps; args=[]; setter_arg=None; rty=ty; use_array_syntax=false; is_getter_setter=true; throws } in
       Decl_FunType(f, fty, Range($symbolstartpos, $endpos)) }
 | GETTER f = ident throws=throws ps = parameters_opt EQ_GT ty = ty BEGIN b = block END
-    { let fty = { parameters=ps; args=[]; setter_arg=None; rty=Some ty; use_array_syntax=false; is_getter_setter=true; throws } in
+    { let fty = { parameters=ps; args=[]; setter_arg=None; rty=ty; use_array_syntax=false; is_getter_setter=true; throws } in
       Decl_FunDefn(f, fty, b, Range($symbolstartpos, $endpos)) }
 | GETTER f = ident throws=throws ps = parameters_opt LBRACK args = formal_list RBRACK EQ_GT ty = ty SEMICOLON
-    { let fty = { parameters=ps; args; setter_arg=None; rty=Some ty; use_array_syntax=true; is_getter_setter=true; throws } in
+    { let fty = { parameters=ps; args; setter_arg=None; rty=ty; use_array_syntax=true; is_getter_setter=true; throws } in
       Decl_FunType(f, fty, Range($symbolstartpos, $endpos)) }
 | GETTER f = ident throws=throws ps = parameters_opt LBRACK args = formal_list RBRACK EQ_GT ty = ty BEGIN b = block END
-    { let fty = { parameters=ps; args; setter_arg=None; rty=Some ty; use_array_syntax=true; is_getter_setter=true; throws } in
+    { let fty = { parameters=ps; args; setter_arg=None; rty=ty; use_array_syntax=true; is_getter_setter=true; throws } in
       Decl_FunDefn(f, fty, b, Range($symbolstartpos, $endpos)) }
 
 setter_declaration:
 | SETTER f = ident throws=throws ps = parameters_opt EQ v = ident COLON ty = ty SEMICOLON
-    { let fty = { parameters=ps; args=[]; setter_arg=Some (v, ty); rty=None; use_array_syntax=false; is_getter_setter=true; throws } in
+    { let fty = { parameters=ps; args=[]; setter_arg=Some (v, ty); rty=Asl_utils.type_unit; use_array_syntax=false; is_getter_setter=true; throws } in
       Decl_FunType(f, fty, Range($symbolstartpos, $endpos)) }
 | SETTER f = ident throws=throws ps = parameters_opt EQ v = ident COLON ty = ty BEGIN b = block END
-    { let fty = { parameters=ps; args=[]; setter_arg=Some (v, ty); rty=None; use_array_syntax=false; is_getter_setter=true; throws } in
+    { let fty = { parameters=ps; args=[]; setter_arg=Some (v, ty); rty=Asl_utils.type_unit; use_array_syntax=false; is_getter_setter=true; throws } in
       Decl_FunDefn(f, fty, b, Range($symbolstartpos, $endpos)) }
 | SETTER f = ident throws=throws ps = parameters_opt LBRACK args = formal_list RBRACK EQ v = ident COLON ty = ty SEMICOLON
-    { let fty = { parameters=ps; args; setter_arg=Some (v, ty); rty=None; use_array_syntax=true; is_getter_setter=true; throws } in
+    { let fty = { parameters=ps; args; setter_arg=Some (v, ty); rty=Asl_utils.type_unit; use_array_syntax=true; is_getter_setter=true; throws } in
       Decl_FunType(f, fty, Range($symbolstartpos, $endpos)) }
 | SETTER f = ident throws=throws ps = parameters_opt LBRACK args = formal_list RBRACK EQ v = ident COLON ty = ty BEGIN b = block END
-    { let fty = { parameters=ps; args; setter_arg=Some (v, ty); rty=None; use_array_syntax=true; is_getter_setter=true; throws } in
+    { let fty = { parameters=ps; args; setter_arg=Some (v, ty); rty=Asl_utils.type_unit; use_array_syntax=true; is_getter_setter=true; throws } in
       Decl_FunDefn(f, fty, b, Range($symbolstartpos, $endpos)) }
 
 internal_definition:
@@ -428,9 +429,9 @@ simple_stmt:
 | f = ident throws1=throws LPAREN args = separated_list(COMMA, arg) RPAREN throws2=throws SEMICOLON
     { Stmt_UCall(f, args, (if throws1<>NoThrow then throws1 else throws2), Range($symbolstartpos, $endpos)) }
 | RETURN e = expr SEMICOLON
-    { Stmt_FunReturn(e, Range($symbolstartpos, $endpos)) }
+    { Stmt_Return(e, Range($symbolstartpos, $endpos)) }
 | RETURN SEMICOLON
-    { Stmt_ProcReturn(Range($symbolstartpos, $endpos)) }
+    { Stmt_Return(Expr_Tuple([]), Range($symbolstartpos, $endpos)) }
 | ASSERT e = expr SEMICOLON
     { Stmt_Assert(e, Range($symbolstartpos, $endpos)) }
 | THROW e = expr SEMICOLON

--- a/libASL/asl_utils.ml
+++ b/libASL/asl_utils.ml
@@ -480,8 +480,7 @@ let stmt_loc (x : AST.stmt) : Loc.t =
   | Stmt_Assign (l, r, loc) -> loc
   | Stmt_TCall (f, tes, args, throws, loc) -> loc
   | Stmt_UCall (f, args, throws, loc) -> loc
-  | Stmt_FunReturn (e, loc) -> loc
-  | Stmt_ProcReturn loc -> loc
+  | Stmt_Return (e, loc) -> loc
   | Stmt_Assert (e, loc) -> loc
   | Stmt_Throw (v, loc) -> loc
   | Stmt_Block (b, loc) -> loc

--- a/libASL/asl_utils.ml
+++ b/libASL/asl_utils.ml
@@ -816,6 +816,10 @@ let subst_type (s : expr Bindings.t) (x : ty) : ty =
   let subst = new substClass s in
   visit_type subst x
 
+let subst_funtype (s : expr Bindings.t) (x : function_type) : function_type =
+  let subst = new substClass s in
+  visit_funtype subst [] x
+
 let subst_decl_item (s : expr Bindings.t) (x : decl_item) : decl_item =
   let subst = new substClass s in
   visit_decl_item subst x

--- a/libASL/asl_utils.mli
+++ b/libASL/asl_utils.mli
@@ -210,6 +210,7 @@ val subst_lexpr : AST.expr Bindings.t -> AST.lexpr -> AST.lexpr
 val subst_var : AST.expr Bindings.t -> Asl_visitor.access_kind -> Ident.t -> Ident.t
 val subst_slice : AST.expr Bindings.t -> AST.slice -> AST.slice
 val subst_type : AST.expr Bindings.t -> AST.ty -> AST.ty
+val subst_funtype : AST.expr Bindings.t -> AST.function_type -> AST.function_type
 val subst_decl_item : AST.expr Bindings.t -> AST.decl_item -> AST.decl_item
 
 (** More flexible substitution class - takes a function instead

--- a/libASL/asl_visitor.ml
+++ b/libASL/asl_visitor.ml
@@ -465,10 +465,9 @@ and visit_stmt (vis : aslVisitor) (x : stmt) : stmt list =
         let args' = visit_args vis args in
         if f == f' && args == args' then x
         else Stmt_UCall (f', args', throws, loc)
-    | Stmt_FunReturn (e, loc) ->
+    | Stmt_Return (e, loc) ->
         let e' = visit_expr vis e in
-        if e == e' then x else Stmt_FunReturn (e', loc)
-    | Stmt_ProcReturn _ -> x
+        if e == e' then x else Stmt_Return (e', loc)
     | Stmt_Assert (e, loc) ->
         let e' = visit_expr vis e in
         if e == e' then x else Stmt_Assert (e', loc)
@@ -590,7 +589,7 @@ let visit_funtype (vis : aslVisitor) (locals : Ident.t list) (fty : function_typ
   let parameters' = with_locals vis locals (visit_parameters vis) fty.parameters in
   let args' = with_locals vis locals (visit_args vis) fty.args in
   let setter_arg' = mapOptionNoCopy (visit_arg_no_default vis) fty.setter_arg in
-  let rty' = mapOptionNoCopy (fun ty -> with_locals vis locals (visit_type vis) ty) fty.rty in
+  let rty' = with_locals vis locals (visit_type vis) fty.rty in
   if fty.parameters == parameters'
   && fty.args == args'
   && fty.setter_arg == setter_arg'

--- a/libASL/global_checks.ml
+++ b/libASL/global_checks.ml
@@ -109,8 +109,7 @@ let rec canthrow_stmt (x : AST.stmt) : status =
       | MayThrow -> maythrow
       | AlwaysThrow -> throw
       )
-  | Stmt_FunReturn (e, loc) -> status_seq (canthrow_expr e) return
-  | Stmt_ProcReturn loc -> return
+  | Stmt_Return (e, loc) -> status_seq (canthrow_expr e) return
   | Stmt_Assert (e, loc) -> ok
   | Stmt_Throw (e, loc) -> throw
   | Stmt_Block (b, loc) -> canthrow_stmts b
@@ -183,7 +182,7 @@ class check_defn_exception_class =
                 FMT.funname f
                 fmt_status s
           end;
-          let should_return = Option.is_some fty.rty in
+          let should_return = ( match fty.rty with Type_Tuple([]) -> false | _ -> true ) in
           if s <> fail then begin
               ( match fty.throws with
               | NoThrow when s.exc ->

--- a/libASL/utils.ml
+++ b/libASL/utils.ml
@@ -31,6 +31,9 @@ let to_file (filename : string) (pp : Format.formatter -> unit) : unit =
   Format.pp_print_flush fmt ();
   close_out chan
 
+let null_formatter : Format.formatter =
+  Format.make_formatter (fun _ _ _ -> ()) (fun _ -> ())
+
 (****************************************************************
  * List related
  ****************************************************************)

--- a/libASL/utils.mli
+++ b/libASL/utils.mli
@@ -21,6 +21,8 @@ val to_string2 : (Format.formatter -> unit) -> string
 
 val to_file : string -> (Format.formatter -> unit) -> unit
 
+val null_formatter : Format.formatter
+
 (****************************************************************
  * List related
  ****************************************************************)

--- a/libASL/value.ml
+++ b/libASL/value.ml
@@ -36,7 +36,7 @@ type value =
 (** {2 Exceptions thrown by interpreter}                        *)
 (****************************************************************)
 
-exception Return of value option
+exception Return of value
 exception EvalError of (Loc.t * string)
 exception Throw of (Loc.t * value)
 exception EndExecution of Loc.t

--- a/libASL/value.mli
+++ b/libASL/value.mli
@@ -21,7 +21,7 @@ type value =
   | VRAM of Primops.ram
   | VUninitialized
 
-exception Return of value option
+exception Return of value
 exception EvalError of (Loc.t * string)
 exception Throw of (Loc.t * value)
 exception EndExecution of Loc.t

--- a/libASL/xform_constprop.ml
+++ b/libASL/xform_constprop.ml
@@ -72,9 +72,6 @@ module Env = struct
   let fun_return (env : t) (r : Values.t) : unit =
     ScopeStack.map_inplace (Fun.const Values.top) env.locals
 
-  let proc_return (env : t) : unit =
-    ScopeStack.map_inplace (Fun.const Values.top) env.locals
-
   let throw (env : t) : unit =
     ScopeStack.map_inplace (Fun.const Values.top) env.locals
 
@@ -468,13 +465,10 @@ and xform_stmt (env : Env.t) (x : AST.stmt) : AST.stmt list =
       let tes' = xform_exprs env tes in
       let es' = xform_exprs env es in
       [ Stmt_TCall (f, tes', es', throws, loc) ]
-  | Stmt_FunReturn (e, loc) ->
+  | Stmt_Return (e, loc) ->
       let e' = xform_expr env e in
       Env.fun_return env (expr_value env e');
-      [ Stmt_FunReturn (e', loc) ]
-  | Stmt_ProcReturn loc ->
-      Env.proc_return env;
-      [ Stmt_ProcReturn loc ]
+      [ Stmt_Return (e', loc) ]
   | Stmt_Assert (e, loc) ->
       let e' = xform_expr env e in
       if e' = asl_true then

--- a/libASL/xform_mono.ml
+++ b/libASL/xform_mono.ml
@@ -202,7 +202,7 @@ class monoClass
               List.iter2 (fun nm sz -> Printf.printf " %s->%d" (Ident.to_string nm) (Z.to_int sz)) tvs szs;
               Printf.printf "\n";
             end;
-            let rty' = Option.map (Xform_constprop.xform_ty env) fty.rty in
+            let rty' = Xform_constprop.xform_ty env fty.rty in
             let pnames = List.map fst fty.parameters in
             let atys' = List.filter (fun (v, _, _) -> not (List.mem v pnames)) fty.args
                      |> List.map (fun (v, ty, od) -> (v, Xform_constprop.xform_ty env ty, Option.map (Xform_constprop.xform_expr env) od))

--- a/libASL/xform_wrap.ml
+++ b/libASL/xform_wrap.ml
@@ -74,13 +74,13 @@ let xform_decl (replacer : replaceClass) (d : AST.declaration) :
         parameters=[];
         args=[(i, ixtype_basetype ixty, None)];
         setter_arg=None;
-        rty=Some ty;
+        rty=ty;
         use_array_syntax=false;
         is_getter_setter=false;
         throws=NoThrow
       } in
       let rd_type = AST.Decl_FunType (rd_f, rd_fty, loc) in
-      let rd_body = [ AST.Stmt_FunReturn (Expr_Array (Expr_Var v, Expr_Var i), loc) ] in
+      let rd_body = [ AST.Stmt_Return (Expr_Array (Expr_Var v, Expr_Var i), loc) ] in
       let rd_defn = AST.Decl_FunDefn (rd_f, rd_fty, rd_body, loc) in
 
       let wr_f = mk_write_fident v in
@@ -88,7 +88,7 @@ let xform_decl (replacer : replaceClass) (d : AST.declaration) :
       let wr_fty : AST.function_type = {
         parameters=[];
         args=[(i, ixtype_basetype ixty, None); (vl, ty, None)];
-        rty=None;
+        rty=type_unit;
         setter_arg=None;
         use_array_syntax=false;
         is_getter_setter=false;
@@ -104,14 +104,14 @@ let xform_decl (replacer : replaceClass) (d : AST.declaration) :
       let rd_fty : AST.function_type = {
         parameters=[];
         args=[];
-        rty=Some ty;
+        rty=ty;
         setter_arg=None;
         use_array_syntax=false;
         is_getter_setter=false;
         throws=NoThrow
       } in
       let rd_type = AST.Decl_FunType (rd_f, rd_fty, loc) in
-      let rd_body = [ AST.Stmt_FunReturn (Expr_Var v, loc) ] in
+      let rd_body = [ AST.Stmt_Return (Expr_Var v, loc) ] in
       let rd_defn = AST.Decl_FunDefn (rd_f, rd_fty, rd_body, loc) in
 
       let wr_f = mk_write_fident v in
@@ -119,7 +119,7 @@ let xform_decl (replacer : replaceClass) (d : AST.declaration) :
       let wr_fty : AST.function_type = {
         parameters=[];
         args=[(vl, ty, None)];
-        rty=None;
+        rty=type_unit;
         setter_arg=None;
         use_array_syntax=false;
         is_getter_setter=false;

--- a/tests/backends/bool_and_00.asl
+++ b/tests/backends/bool_and_00.asl
@@ -1,0 +1,26 @@
+// RUN: %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+func Test(x : boolean, y : boolean) => bits(4)
+begin
+    return
+        (if x && y then
+            '1001'
+        else
+            '1011'
+        );
+end
+
+func main() => integer
+begin
+    print_bits_hex(Test(TRUE, TRUE)); println();
+    // CHECK: 4'x9
+    print_bits_hex(Test(TRUE, FALSE)); println();
+    // CHECK: 4'xb
+    print_bits_hex(Test(FALSE, TRUE)); println();
+    // CHECK: 4'xb
+    print_bits_hex(Test(FALSE, FALSE)); println();
+    // CHECK: 4'xb
+
+    return 0;
+end

--- a/tests/backends/bool_eq_00.asl
+++ b/tests/backends/bool_eq_00.asl
@@ -1,0 +1,26 @@
+// RUN: %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+func Test(x : boolean, y : boolean) => bits(4)
+begin
+    return
+        (if x == y then
+            '1001'
+        else
+            '1011'
+        );
+end
+
+func main() => integer
+begin
+    print_bits_hex(Test(TRUE, TRUE)); println();
+    // CHECK: 4'x9
+    print_bits_hex(Test(TRUE, FALSE)); println();
+    // CHECK: 4'xb
+    print_bits_hex(Test(FALSE, TRUE)); println();
+    // CHECK: 4'xb
+    print_bits_hex(Test(FALSE, FALSE)); println();
+    // CHECK: 4'x9
+
+    return 0;
+end

--- a/tests/backends/bool_ne_00.asl
+++ b/tests/backends/bool_ne_00.asl
@@ -1,0 +1,26 @@
+// RUN: %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+func Test(x : boolean, y : boolean) => bits(4)
+begin
+    return
+        (if x != y then
+            '1001'
+        else
+            '1011'
+        );
+end
+
+func main() => integer
+begin
+    print_bits_hex(Test(TRUE, TRUE)); println();
+    // CHECK: 4'xb
+    print_bits_hex(Test(TRUE, FALSE)); println();
+    // CHECK: 4'x9
+    print_bits_hex(Test(FALSE, TRUE)); println();
+    // CHECK: 4'x9
+    print_bits_hex(Test(FALSE, FALSE)); println();
+    // CHECK: 4'xb
+
+    return 0;
+end

--- a/tests/backends/bool_not_00.asl
+++ b/tests/backends/bool_not_00.asl
@@ -1,0 +1,22 @@
+// RUN: %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+func Test(x : boolean) => bits(4)
+begin
+    return
+        (if !x then
+            '1001'
+        else
+            '1011'
+        );
+end
+
+func main() => integer
+begin
+    print_bits_hex(Test(TRUE)); println();
+    // CHECK: 4'xb
+    print_bits_hex(Test(FALSE)); println();
+    // CHECK: 4'x9
+
+    return 0;
+end

--- a/tests/backends/bool_or_00.asl
+++ b/tests/backends/bool_or_00.asl
@@ -1,0 +1,26 @@
+// RUN: %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+func Test(x : boolean, y : boolean) => bits(4)
+begin
+    return
+        (if x || y then
+            '1001'
+        else
+            '1011'
+        );
+end
+
+func main() => integer
+begin
+    print_bits_hex(Test(TRUE, TRUE)); println();
+    // CHECK: 4'x9
+    print_bits_hex(Test(TRUE, FALSE)); println();
+    // CHECK: 4'x9
+    print_bits_hex(Test(FALSE, TRUE)); println();
+    // CHECK: 4'x9
+    print_bits_hex(Test(FALSE, FALSE)); println();
+    // CHECK: 4'xb
+
+    return 0;
+end

--- a/tests/backends/stmt_if_00.asl
+++ b/tests/backends/stmt_if_00.asl
@@ -1,27 +1,22 @@
 // RUN: %aslrun %s | filecheck %s
 // Copyright (C) 2023-2025 Intel Corporation
 
-func Test(x : boolean, y : boolean) => bits(4)
+func Test(x : boolean) => bits(4)
 begin
+    var r = '0000';
     if x then
-        return '0001';
-    elsif y then 
-        return '0010';
+        r = '0001';
     else
-        return '0011';
+        r = '0011';
     end
-    return '0100';
+    return r;
 end
 
 func main() => integer
 begin
-    print_bits_hex(Test(TRUE, FALSE)); println();
+    print_bits_hex(Test(TRUE)); println();
     // CHECK: 4'x1
-    print_bits_hex(Test(TRUE, TRUE)); println();
-    // CHECK: 4'x1
-    print_bits_hex(Test(FALSE, TRUE)); println();
-    // CHECK: 4'x2
-    print_bits_hex(Test(FALSE, FALSE)); println();
+    print_bits_hex(Test(FALSE)); println();
     // CHECK: 4'x3
 
     return 0;

--- a/tests/backends/stmt_if_01.asl
+++ b/tests/backends/stmt_if_01.asl
@@ -1,0 +1,29 @@
+// RUN: %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+func Test(x : boolean, y : boolean) => bits(4)
+begin
+    if x then
+        return '0001';
+    elsif y then 
+        return '0010';
+    else
+        return '0011';
+    end
+    return '0100';
+end
+
+func main() => integer
+begin
+    print_bits_hex(Test(TRUE, FALSE)); println();
+    // CHECK: 4'x1
+    print_bits_hex(Test(TRUE, TRUE)); println();
+    // CHECK: 4'x1
+    print_bits_hex(Test(FALSE, TRUE)); println();
+    // CHECK: 4'x2
+    print_bits_hex(Test(FALSE, FALSE)); println();
+    // CHECK: 4'x3
+
+    return 0;
+end
+

--- a/tests/backends/stmt_if_02.asl
+++ b/tests/backends/stmt_if_02.asl
@@ -1,0 +1,29 @@
+// RUN: %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+func Test(x : boolean, y : boolean) => bits(4)
+begin
+    var r = '0000';
+    if x then
+        r = '0001';
+    elsif y then
+        r = '0010';
+    else
+        r = '0011';
+    end
+    return r;
+end
+
+func main() => integer
+begin
+    print_bits_hex(Test(FALSE, FALSE)); println();
+    // CHECK: 4'x3
+    print_bits_hex(Test(FALSE, TRUE)); println();
+    // CHECK: 4'x2
+    print_bits_hex(Test(TRUE, FALSE)); println();
+    // CHECK: 4'x1
+    print_bits_hex(Test(TRUE, TRUE)); println();
+    // CHECK: 4'x1
+
+    return 0;
+end


### PR DESCRIPTION
This merges Stmt_ProcReturn and Stmt_FunReturn
and changes the optional return type to a
mandatory return type that is unit for procedures.