### PR TITLE
Cleanup: stmt/expr_if

### DIFF
--- a/libASL/asl_ast.ml
+++ b/libASL/asl_ast.ml
@@ -68,7 +68,7 @@ pattern =
  | Pat_Single of expr
 
 and expr =
-   Expr_If of expr * expr * e_elsif list * expr
+   Expr_If of (expr * expr) list * expr
  | Expr_Let of Ident.t * ty * expr * expr (* IR extension, not intended for use in specs *)
  | Expr_Assert of expr * expr * Loc.t (* IR extension, not intended for use in specs *)
  | Expr_Binop of expr * binop * expr
@@ -91,12 +91,11 @@ and expr =
  | Expr_Array of expr * expr (* array accesses *)
  | Expr_Lit of Value.value
 
+and e_elsif = (expr * expr)
+
 and change =
  | Change_Field of Ident.t
  | Change_Slices of slice list
-
-and e_elsif =
-   E_Elsif_Cond of expr * expr
 
 and slice =
    Slice_Single of expr
@@ -161,15 +160,14 @@ and stmt =
  | Stmt_UCall of Ident.t * (Ident.t option * expr) list * can_throw * Loc.t (* procedure call before typechecking - optional name arguments, no type parameters *)
  | Stmt_TCall of Ident.t * expr list * expr list * can_throw * Loc.t (* procedure call with explicit type parameters *)
  | Stmt_VarDeclsNoInit of Ident.t list * ty * Loc.t
- | Stmt_If of expr * stmt list * s_elsif list * (stmt list * Loc.t) * Loc.t
+ | Stmt_If of s_elsif list * (stmt list * Loc.t) * Loc.t
  | Stmt_Case of expr * ty option * alt list * (stmt list * Loc.t) option * Loc.t
  | Stmt_For of Ident.t * ty * expr * direction * expr * stmt list * Loc.t
  | Stmt_While of expr * stmt list * Loc.t
  | Stmt_Repeat of stmt list * expr * Loc.pos * Loc.t
  | Stmt_Try of stmt list * Loc.pos * catcher list * (stmt list * Loc.t) option * Loc.t
 
-and s_elsif =
-   S_Elsif_Cond of expr * stmt list * Loc.t
+and s_elsif = (expr * stmt list * Loc.t)
 
 and alt =
    Alt_Alt of pattern list * expr option * stmt list * Loc.t

--- a/libASL/asl_parser.mly
+++ b/libASL/asl_parser.mly
@@ -439,13 +439,14 @@ simple_stmt:
 
 conditional_stmt:
 | IF c = expr THEN t = block els = list(s_elsif) f = optional_else END
-    { Stmt_If(c, t, els, f, Range($symbolstartpos, $endpos)) }
+    { let loc = Range($symbolstartpos, $endpos(t)) in
+      Stmt_If((c, t, loc)::els, f, Range($symbolstartpos, $endpos)) }
 | CASE e = expr OF alts = nonempty_list(alt) ob = opt_otherwise END
     { Stmt_Case(e, None, alts, ob, Range($symbolstartpos, $endpos)) }
 
 s_elsif:
 | ELSIF c = expr THEN b = block
-    { S_Elsif_Cond(c, b, Range($symbolstartpos, $endpos)) }
+    { (c, b, Range($symbolstartpos, $endpos)) }
 
 optional_else:
 | ELSE b = block { (b, Range($symbolstartpos, $endpos)) }
@@ -512,7 +513,7 @@ expr:
 
 conditional_expression:
 | IF c = cexpr THEN t = expr els = list(e_elsif) ELSE e = expr
-    { Expr_If(c, t, els, e) }
+    { Expr_If((c, t)::els, e) }
 | UNDERSCORE_UNDERSCORE_LET v = ident COLON ty = ty EQ e = expr UNDERSCORE_UNDERSCORE_IN b = expr
     { Expr_Let(v, ty, e, b) }
 | UNDERSCORE_UNDERSCORE_ASSERT e1 = expr UNDERSCORE_UNDERSCORE_IN e2 = expr
@@ -520,7 +521,7 @@ conditional_expression:
 | cexpr = cexpr { cexpr }
 
 e_elsif:
-| ELSIF c = expr THEN e = expr { E_Elsif_Cond(c, e) }
+| ELSIF c = expr THEN e = expr { (c, e) }
 
 cexpr:
 | bexpr = bexpr fs = list(factor)

--- a/libASL/asl_utils.ml
+++ b/libASL/asl_utils.ml
@@ -484,7 +484,7 @@ let stmt_loc (x : AST.stmt) : Loc.t =
   | Stmt_Assert (e, loc) -> loc
   | Stmt_Throw (v, loc) -> loc
   | Stmt_Block (b, loc) -> loc
-  | Stmt_If (c, t, els, (e, el), loc) -> loc
+  | Stmt_If (els, (e, el), loc) -> loc
   | Stmt_Case (e, oty, alts, ob, loc) -> loc
   | Stmt_For (v, ty, f, dir, t, b, loc) -> loc
   | Stmt_While (c, b, loc) -> loc

--- a/libASL/asl_visitor.ml
+++ b/libASL/asl_visitor.ml
@@ -95,11 +95,12 @@ and visit_lvar (vis : aslVisitor) (x : Ident.t) : Ident.t =
 
 and visit_e_elsif (vis : aslVisitor) (x : e_elsif) : e_elsif =
   let aux (vis : aslVisitor) (x : e_elsif) : e_elsif =
-    match x with
-    | E_Elsif_Cond (c, e) ->
+    ( match x with
+    | (c, e) ->
         let c' = visit_expr vis c in
         let e' = visit_expr vis e in
-        if c == c' && e == e' then x else E_Elsif_Cond (c', e')
+        if c == c' && e == e' then x else (c', e')
+    )
   in
   doVisit vis (vis#ve_elsif x) aux x
 
@@ -175,13 +176,11 @@ and visit_pattern (vis : aslVisitor) (x : pattern) : pattern =
 and visit_expr (vis : aslVisitor) (x : expr) : expr =
   let aux (vis : aslVisitor) (x : expr) : expr =
     ( match x with
-    | Expr_If (c, t, els, e) ->
-        let c' = visit_expr vis c in
-        let t' = visit_expr vis t in
+    | Expr_If (els, e) ->
         let els' = mapNoCopy (visit_e_elsif vis) els in
         let e' = visit_expr vis e in
-        if c == c' && t == t' && els == els' && e == e' then x
-        else Expr_If (c', t', els', e')
+        if els == els' && e == e' then x
+        else Expr_If (els', e')
     | Expr_Let (v, t, e, b) ->
         let v' = visit_var vis Definition v in
         let t' = visit_type vis t in
@@ -477,13 +476,11 @@ and visit_stmt (vis : aslVisitor) (x : stmt) : stmt list =
     | Stmt_Block (b, loc) ->
         let b' = visit_stmts vis b in
         if b == b' then x else Stmt_Block (b', loc)
-    | Stmt_If (c, t, els, (e, el), loc) ->
-        let c' = visit_expr vis c in
-        let t' = visit_stmts vis t in
+    | Stmt_If (els, (e, el), loc) ->
         let els' = mapNoCopy (visit_s_elsif vis) els in
         let e' = visit_stmts vis e in
-        if c == c' && t == t' && els == els' && e == e' then x
-        else Stmt_If (c', t', els', (e', el), loc)
+        if els == els' && e == e' then x
+        else Stmt_If (els', (e', el), loc)
     | Stmt_Case (e, oty, alts, ob, loc) ->
         let e' = visit_expr vis e in
         let oty' = mapOptionNoCopy (visit_type vis) oty in
@@ -518,11 +515,12 @@ and visit_stmt (vis : aslVisitor) (x : stmt) : stmt list =
 
 and visit_s_elsif (vis : aslVisitor) (x : s_elsif) : s_elsif =
   let aux (vis : aslVisitor) (x : s_elsif) : s_elsif =
-    match x with
-    | S_Elsif_Cond (c, b, loc) ->
+    ( match x with
+    | (c, b, loc) ->
         let c' = visit_expr vis c in
         let b' = visit_stmts vis b in
-        if c == c' && b == b' then x else S_Elsif_Cond (c', b', loc)
+        if c == c' && b == b' then x else (c', b', loc)
+    )
   in
   doVisit vis (vis#vs_elsif x) aux x
 

--- a/libASL/global_checks.ml
+++ b/libASL/global_checks.ml
@@ -113,9 +113,8 @@ let rec canthrow_stmt (x : AST.stmt) : status =
   | Stmt_Assert (e, loc) -> ok
   | Stmt_Throw (e, loc) -> throw
   | Stmt_Block (b, loc) -> canthrow_stmts b
-  | Stmt_If (c, t, els, (e, el), loc) ->
-      let els' = AST.S_Elsif_Cond (c, t, loc) :: els in
-      let rs = List.map (function AST.S_Elsif_Cond(e, b, _) -> status_seq (canthrow_expr e) (canthrow_stmts b)) els' in
+  | Stmt_If (els, (e, el), loc) ->
+      let rs = List.map (function (e, b, _) -> status_seq (canthrow_expr e) (canthrow_stmts b)) els in
       let r = canthrow_stmts e in
       List.fold_left status_merge r rs
   | Stmt_Case (e, oty, alts, ob, loc) ->

--- a/libASL/xform_case.ml
+++ b/libASL/xform_case.ml
@@ -12,10 +12,6 @@ module AST = Asl_ast
 open Asl_utils
 open Builtin_idents
 
-let mk_elsif (x : (AST.expr * AST.stmt list * Loc.t)) : AST.s_elsif =
-  let (e, b, loc) = x in
-  AST.S_Elsif_Cond (e, b, loc)
-
 let mk_if
     (branches : (AST.expr * AST.stmt list * Loc.t) list)
     (d : (AST.stmt list * Loc.t))
@@ -23,7 +19,7 @@ let mk_if
   : AST.stmt list =
   ( match branches with
   | [] -> fst d
-  | ((c, t, loc) :: branches) -> [Stmt_If (c, t, List.map mk_elsif branches, d, loc)]
+  | _ -> [Stmt_If (branches, d, loc)]
   )
 
 let rec match_pattern (loc : Loc.t) (e : AST.expr) (p : AST.pattern) : AST.expr =


### PR DESCRIPTION
This change treats the initial 'if c then t' clause as just a special case of the remaining 'elsif c then t' clauses.

In almost all cases, this makes code simpler/shorter.