### PR TITLE
Update (fix) GitHub action

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup OCaml
         uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: 4
+          ocaml-compiler: 5
 
       - name: Install APT dependencies
         run: |
@@ -40,8 +40,9 @@ jobs:
 
       - name: Install OCaml tools and libraries
         run: |
-          opam init --no-setup --disable-sandboxing --compiler=4.14.3
-          opam env
+          opam init --no-setup --disable-sandboxing
+          opam switch create 5.4.1
+          eval $(opam env --switch=5.4.1)
           opam install . --deps-only --with-test --with-doc --locked --yes
 
       - name: Build

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,9 +15,14 @@ jobs:
 
     steps:
       - name: Check out
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
         with:
           submodules: recursive
+
+      - name: Setup OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: 4
 
       - name: Install APT dependencies
         run: |
@@ -33,22 +38,9 @@ jobs:
       - name: Install Python dependencies
         run: python3 -m pip install --no-deps --require-hashes --requirement requirements.txt
 
-        # The Opam package manager used by ocaml recompiles everything from source
-        # Installing the z3 library is especially slow
-        # So we cache the binaries generated from the build
-        # Note that this does not check hashes of dependencies so we may need to delete
-        # the cache manually every now and then.
-      - name: Cache OCaml tools and libraries
-        id: cache-opam
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
-        with:
-          path: ~/work/asl-interpreter/asl-interpreter/.opam
-          key: opam
-
       - name: Install OCaml tools and libraries
-        if: steps.cache-opam.outputs.cache-hit != 'true'
         run: |
-          opam init --no-setup --disable-sandboxing --compiler=4.14.2
+          opam init --no-setup --disable-sandboxing --compiler=4.14.3
           opam env
           opam install . --deps-only --with-test --with-doc --locked --yes
 

--- a/Makefile
+++ b/Makefile
@@ -32,17 +32,17 @@ build::
 
 install::
 	$(DUNE) build @install
-	${RM} -r ${OPAM_SWITCH_PREFIX}/lib/asli/*
+	${RM} -r ${OPAM_SWITCH_PREFIX}/lib/isa-tools/*
 	$(DUNE) install
 
 uninstall::
 	$(DUNE) build @install
 	$(DUNE) uninstall
-	${RM} -r ${OPAM_SWITCH_PREFIX}/lib/asli/*
+	${RM} -r ${OPAM_SWITCH_PREFIX}/lib/isa-tools/*
 
 publish::
 	$(DUNE) build @install
-	$(OPAM) publish https://github.com/alastairreid/asl-interpreter/archive/$(VERSION).tar.gz
+	$(OPAM) publish https://github.com/IntelLabs/isa-tools/archive/$(VERSION).tar.gz
 
 doc::
 	$(DUNE) build @doc
@@ -103,16 +103,16 @@ build_systemc:
 
 test_backend_sc: build_systemc
 
-asli.opam.locked:
+isa-tools.opam.locked:
 	opam lock .
 
 # This target can be used to create reproducible builds
 # by installing exactly the versions of dependencies that
-# are specified in the asli.opam.locked file.
+# are specified in the isa-tools.opam.locked file.
 # It is not essential to use this step but we will try to
 # keep the locked file up to date so that it is always a good
 # / reliable option.
-install_dependencies: asli.opam.locked
+install_dependencies: isa-tools.opam.locked
 	opam install . --deps-only --locked
 
 ################################################################

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The following commands are sufficient to install requirements and to build iii o
     apt update
     apt install -y libgmp-dev opam pkg-config
     pip3 install -r requirements.txt
-    opam init --no-setup --disable-sandboxing --compiler=4.14.3
+    opam init --no-setup --disable-sandboxing --compiler=5.4.1
     opam install . --deps-only --with-test --with-doc --locked --yes
     eval $(opam env)
 
@@ -100,7 +100,7 @@ not work because it limits the use of bit-precise integers to 128 bits.
     opam init
     eval $(opam env --switch=default)
     pip3 install -r requirements.txt
-    opam init --no-setup --disable-sandboxing --compiler=4.14.2
+    opam init --no-setup --disable-sandboxing --compiler=5.4.1
     opam install . --deps-only --with-test --with-doc --locked --yes
     eval $(opam env)
     git submodule init

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The following commands are sufficient to install requirements and to build iii o
     apt update
     apt install -y libgmp-dev opam pkg-config
     pip3 install -r requirements.txt
-    opam init --no-setup --disable-sandboxing --compiler=4.14.2
+    opam init --no-setup --disable-sandboxing --compiler=4.14.3
     opam install . --deps-only --with-test --with-doc --locked --yes
     eval $(opam env)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ISA Interpreter
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/IntelLabs/asl-interpreter/badge)](https://scorecard.dev/viewer/?uri=github.com/IntelLabs/asl-interpreter)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/IntelLabs/isa-tools/badge)](https://scorecard.dev/viewer/?uri=github.com/IntelLabs/isa-tools)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9891/badge)](https://www.bestpractices.dev/projects/9891)
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
@@ -53,9 +53,9 @@ Please run the tests by running `make test` before creating a pull request.
 
 # Feedback
 We encourage feedback and suggestions via
-[GitHub Issues](https://github.com/IntelLabs/asl-interpreter/issues) as well
+[GitHub Issues](https://github.com/IntelLabs/isa-tools/issues) as well
 as via
-[GitHub Discussions](https://github.com/IntelLabs/asl-interpreter/discussions).
+[GitHub Discussions](https://github.com/IntelLabs/isa-tools/discussions).
 
 
 ## Requirements and Building
@@ -131,7 +131,7 @@ This software includes code from one open source project.
 Since the repository contains submodules, be sure to recursively clone it:
 
 ```
-    git clone --recursive https://github.com/IntelLabs/asl-interpreter.git
+    git clone --recursive https://github.com/IntelLabs/isa-tools.git
 ```
 
 ### Directory structure

--- a/bin/iic.py
+++ b/bin/iic.py
@@ -263,7 +263,7 @@ def get_c_flags(iii, backend):
         # and the include path that we need is ../_build/install/default/runtime/include
         bindir = os.path.dirname(iii)
         rootdir = os.path.dirname(bindir)
-        path = os.path.join(rootdir, "lib/asli/runtime_include")
+        path = os.path.join(rootdir, "lib/isa-tools/runtime_include")
         c_flags = [f"-I{path}"]
     c_flags.extend(backend_c_flags[backend])
     return c_flags
@@ -286,7 +286,7 @@ def get_ld_flags(iii, backend):
         # and the include path that we need is ../_build/install/default/runtime
         bindir = os.path.dirname(iii)
         rootdir = os.path.dirname(bindir)
-        path = os.path.join(rootdir, "lib/asli/runtime/libASL.a")
+        path = os.path.join(rootdir, "lib/isa-tools/runtime/libASL.a")
         ld_flags = [path]
     if backend == "sc":
         sc_types_dir = os.environ.get('SC_TYPES_DIR')

--- a/bin/iii.ml
+++ b/bin/iii.ml
@@ -477,9 +477,9 @@ let main () =
   Tcheck.verbose := verbose 2;
 
   let exe_dir = Filename.dirname (get_executable_path ()) in
-  let stdlib_dir = Filename.concat exe_dir "../share/asli/stdlib" in
-  let runtime_dir = Filename.concat exe_dir "../lib/asli/runtime" in
-  let runtime_include_dir = Filename.concat exe_dir "../lib/asli/runtime_include" in
+  let stdlib_dir = Filename.concat exe_dir "../share/isa-tools/stdlib" in
+  let runtime_dir = Filename.concat exe_dir "../lib/isa-tools/runtime" in
+  let runtime_include_dir = Filename.concat exe_dir "../lib/isa-tools/runtime_include" in
   let default_path = stdlib_dir ^ ":." in
   let legacy_path = Option.value (Sys.getenv_opt "ASL_PATH") ~default:default_path in
   let paths = Option.value (Sys.getenv_opt "ISA_PATH") ~default:legacy_path

--- a/dune-project
+++ b/dune-project
@@ -32,7 +32,7 @@
     ("alcotest"  :with-test)
     "linenoise"
     ("menhir"    :build)
-    ("ocaml"     (>= "4.14"))
+    ("ocaml"     (>= "5.4"))
     ("ocolor"    (>= "1.2.2"))
     "odoc"
     "yojson"

--- a/dune-project
+++ b/dune-project
@@ -1,6 +1,6 @@
 (lang dune 3.13)
 
-(name asli)
+(name isa-tools)
 (version 2.0.0)
 
 ; Copyright Arm Limited (c) 2017-2019
@@ -10,7 +10,7 @@
 (using menhir 3.0)
 
 (package
-  (name asli)
+  (name isa-tools)
   (synopsis "Interpreter for Intel(R) ISA Specification Language")
   (description "\| Intel(R) ISA Specification Language is an executable language for writing
                "\| clear, precise specifications of Instruction Set Architectures (ISAs).
@@ -44,9 +44,9 @@
 (license BSD-3-Clause)
 (authors "Alastair Reid")
 (maintainers "Alastair Reid <alastair.reid@intel.com>")
-(source (github IntelLabs/asl-interpreter))
-(bug_reports "https://github.com/IntelLabs/asl-interpreter/issues")
-(homepage "https://github.com/IntelLabs/asl-interpreter")
+(source (github IntelLabs/isa-tools))
+(bug_reports "https://github.com/IntelLabs/isa-tools/issues")
+(homepage "https://github.com/IntelLabs/isa-tools")
 ; (documentation ...)
 
 (generate_opam_files true)

--- a/isa-tools.opam
+++ b/isa-tools.opam
@@ -22,8 +22,8 @@ linked with other C/C++ libraries.
 maintainer: ["Alastair Reid <alastair.reid@intel.com>"]
 authors: ["Alastair Reid"]
 license: "BSD-3-Clause"
-homepage: "https://github.com/IntelLabs/asl-interpreter"
-bug-reports: "https://github.com/IntelLabs/asl-interpreter/issues"
+homepage: "https://github.com/IntelLabs/isa-tools"
+bug-reports: "https://github.com/IntelLabs/isa-tools/issues"
 depends: [
   "dune" {>= "3.13"}
   "alcotest" {with-test}
@@ -50,4 +50,4 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git+https://github.com/IntelLabs/asl-interpreter.git"
+dev-repo: "git+https://github.com/IntelLabs/isa-tools.git"

--- a/isa-tools.opam
+++ b/isa-tools.opam
@@ -29,7 +29,7 @@ depends: [
   "alcotest" {with-test}
   "linenoise"
   "menhir" {build}
-  "ocaml" {>= "4.14"}
+  "ocaml" {>= "5.4"}
   "ocolor" {>= "1.2.2"}
   "odoc"
   "yojson"

--- a/isa-tools.opam.locked
+++ b/isa-tools.opam.locked
@@ -27,6 +27,9 @@ depends: [
   "alcotest" {= "1.9.1" & with-test}
   "astring" {= "0.8.5"}
   "base-bigarray" {= "base"}
+  "base-domains" {= "base"}
+  "base-effects" {= "base"}
+  "base-nnp" {= "base"}
   "base-threads" {= "base"}
   "base-unix" {= "base"}
   "camlp-streams" {= "5.0.1"}
@@ -46,9 +49,10 @@ depends: [
   "menhirGLR" {= "20260209"}
   "menhirLib" {= "20260209"}
   "menhirSdk" {= "20260209"}
-  "ocaml" {= "4.14.3"}
-  "ocaml-base-compiler" {= "4.14.3"}
-  "ocaml-config" {= "2"}
+  "ocaml" {= "5.4.1"}
+  "ocaml-base-compiler" {= "5.4.1"}
+  "ocaml-compiler" {= "5.4.1"}
+  "ocaml-config" {= "3"}
   "ocaml-options-vanilla" {= "1"}
   "ocaml-syntax-shims" {= "1.0.0" & with-test}
   "ocamlbuild" {= "0.16.1"}

--- a/isa-tools.opam.locked
+++ b/isa-tools.opam.locked
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-name: "asli"
+name: "isa-tools"
 version: "2.0.0"
 synopsis: "Interpreter for Intel(R) ISA Specification Language"
 description: """\
@@ -21,37 +21,34 @@ linked with other C/C++ libraries."""
 maintainer: "Alastair Reid <alastair.reid@intel.com>"
 authors: "Alastair Reid"
 license: "BSD-3-Clause"
-homepage: "https://github.com/IntelLabs/asl-interpreter"
-bug-reports: "https://github.com/IntelLabs/asl-interpreter/issues"
+homepage: "https://github.com/IntelLabs/isa-tools"
+bug-reports: "https://github.com/IntelLabs/isa-tools/issues"
 depends: [
-  "alcotest" {= "1.9.0" & with-test}
+  "alcotest" {= "1.9.1" & with-test}
   "astring" {= "0.8.5"}
   "base-bigarray" {= "base"}
-  "base-domains" {= "base"}
-  "base-effects" {= "base"}
-  "base-nnp" {= "base"}
   "base-threads" {= "base"}
   "base-unix" {= "base"}
   "camlp-streams" {= "5.0.1"}
-  "cmdliner" {= "1.3.0"}
+  "cmdliner" {= "2.1.1"}
   "conf-c++" {= "1.0"}
   "conf-gmp" {= "5"}
   "conf-pkg-config" {= "4"}
   "conf-python-3" {= "9.0.0"}
   "cppo" {= "1.8.0"}
   "crunch" {= "4.0.0"}
-  "dune" {= "3.20.1"}
+  "dune" {= "3.22.2"}
   "fmt" {= "0.11.0"}
   "fpath" {= "0.7.3"}
   "linenoise" {= "1.5.1"}
-  "menhir" {= "20240715"}
-  "menhirCST" {= "20240715"}
-  "menhirLib" {= "20240715"}
-  "menhirSdk" {= "20240715"}
-  "ocaml" {= "5.3.0"}
-  "ocaml-base-compiler" {= "5.3.0"}
-  "ocaml-compiler" {= "5.3.0"}
-  "ocaml-config" {= "3"}
+  "menhir" {= "20260209"}
+  "menhirCST" {= "20260209"}
+  "menhirGLR" {= "20260209"}
+  "menhirLib" {= "20260209"}
+  "menhirSdk" {= "20260209"}
+  "ocaml" {= "4.14.3"}
+  "ocaml-base-compiler" {= "4.14.3"}
+  "ocaml-config" {= "2"}
   "ocaml-options-vanilla" {= "1"}
   "ocaml-syntax-shims" {= "1.0.0" & with-test}
   "ocamlbuild" {= "0.16.1"}
@@ -60,28 +57,28 @@ depends: [
   "odoc" {= "3.1.0"}
   "odoc-parser" {= "3.1.0"}
   "ptime" {= "1.2.0"}
-  "re" {= "1.13.2"}
+  "re" {= "1.14.0"}
   "seq" {= "base"}
   "stdlib-shims" {= "0.3.0" & with-test}
-  "topkg" {= "1.1.0"}
+  "topkg" {= "1.1.1"}
   "tyxml" {= "4.6.0"}
   "uutf" {= "1.0.4"}
   "yojson" {= "3.0.0"}
-  "z3" {= "4.14.1"}
+  "z3" {= "4.15.2"}
   "zarith" {= "1.14"}
 ]
 build: [
   ["dune" "subst"] {dev}
   [
-  "dune"
-  "build"
-  "-p"
-  name
-  "-j"
-  jobs
-  "@install"
-  "@runtest" {with-test}
-  "@doc" {with-doc}
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
 ]
-]
-dev-repo: "git+https://github.com/IntelLabs/asl-interpreter.git"
+dev-repo: "git+https://github.com/IntelLabs/isa-tools.git"

--- a/libISA/dune
+++ b/libISA/dune
@@ -23,7 +23,7 @@
 
 (library
  (name libISA)
- (public_name asli.libISA)
+ (public_name isa-tools.libISA)
  (flags
   (:standard -w -27 -cclib -lstdc++))
  (modules

--- a/libISA/dune
+++ b/libISA/dune
@@ -90,4 +90,4 @@
  (libraries menhirLib ocolor str yojson zarith z3))
 
 
-(env (_ (odoc (warnings fatal))))
+; (env (_ (odoc (warnings fatal))))

--- a/libISA/tcheck.ml
+++ b/libISA/tcheck.ml
@@ -2731,7 +2731,7 @@ let tc_print (env : Env.t) (loc : Loc.t) (args : AST.expr list) : AST.stmt list 
       raise (error "Print must always be used with a literal format string like \"x = {x}\"")
   )
 
-(** Extract variable names from a format string like "x={x} y={y}".
+(** Extract variable names from a format string like "x=\{x\} y=\{y\}".
   * Backslash escapes are skipped.
   *)
 let extract_fmt_vars (loc : Loc.t) (fmt : string) : string list =

--- a/libISA/utils.mli
+++ b/libISA/utils.mli
@@ -158,10 +158,10 @@ val round_up_to_pow2 : int -> int
 (** Segments of parsed ASL format string *)
 type fmt_segment =
   | Fmt_lit of string  (** Literal text *)
-  | Fmt_var of string  (** Variable from { } *)
+  | Fmt_var of string  (** Variable from \{ \} *)
 
 (** Parse an ASL format string into segments.
-    Raises Failure if { has no matching }. *)
+    Raises Failure if \{ has no matching \}. *)
 val parse_fmt_string : string -> fmt_segment list
 
 (****************************************************************

--- a/mk_install.py
+++ b/mk_install.py
@@ -6,7 +6,7 @@ a full copy of ~/.opam.
 
 Typical usage:
 
-    cd asl-interpreter
+    cd isa-tools
     ./mk_install.py --release-dir=$HOME/release --version=`date -I`
     # will be released into ${release_dir}/${version}
 
@@ -58,7 +58,7 @@ def main() -> int:
     print(f"Copying release to {release_dir}")
 
     shutil.copytree(f"_build/install/default", release_dir, dirs_exist_ok=True)
-    shutil.rmtree(f"{release_dir}/lib/asli/libISA") # just a copy of the source code
+    shutil.rmtree(f"{release_dir}/lib/isa-tools/libISA") # just a copy of the source code
 
     # copy Z3 file over into release (user will need to set LD_LIBRARY_PATH to lib_dir)
     shutil.copy(f"{opam_switch}/lib/stublibs/libz3.so", lib_dir)


### PR DESCRIPTION
Updates the github action that was failing because of problems in the opam lock file.
While doing this, I renamed the dune files from asl-interpreter to isa-tools

In the process of doing this, I also
- updated the compiler to 5.4.1 to overcome some issues in 'make doc'.
- disabled treatment of warnings as errors in 'make doc' because it was reporting a warning involving the Menhir parser generator and I couldn't see any way to fix or suppress that warning.