### PR TITLE
Fix free variable calculation

### DIFF
--- a/libISA/isa_visitor.ml
+++ b/libISA/isa_visitor.ml
@@ -60,6 +60,19 @@ class type isaVisitor =
   end
 
 (****************************************************************)
+(** {2 Nested scope handler}                                    *)
+(****************************************************************)
+
+(** Handle nested scope by adding a nested scope level with
+ *  list of variables `ls` that are introduced by `f`.
+ *)
+let with_locals (vis : isaVisitor) (ls : Ident.t list) (f : 'a -> 'b) (x: 'a) : 'b =
+  vis#enter_scope ls;
+  let result = f x in
+  vis#leave_scope ls;
+  result
+
+(****************************************************************)
 (** {2 ISA visitor functions}                                   *)
 (****************************************************************)
 
@@ -185,9 +198,11 @@ and visit_expr (vis : isaVisitor) (x : expr) : expr =
         let v' = visit_var vis Definition v in
         let t' = visit_type vis t in
         let e' = visit_expr vis e in
-        let b' = visit_expr vis b in
-        if v == v' && t == t' && e == e' && b == b' then x
-        else Expr_Let (v', t', e', b')
+        with_locals vis [v] (fun _ ->
+          let b' = visit_expr vis b in
+          if v == v' && t == t' && e == e' && b == b' then x
+          else Expr_Let (v', t', e', b')
+        ) ()
     | Expr_Assert (e1, e2, loc) ->
         let e1' = visit_expr vis e1 in
         let e2' = visit_expr vis e2 in
@@ -381,12 +396,6 @@ and visit_lexpr (vis : isaVisitor) (x : lexpr) : lexpr =
         else LExpr_ReadWrite (f', g', tes', es', throws)
   in
   doVisit vis (vis#vlexpr x) aux x
-
-let with_locals (vis : isaVisitor) (ls : Ident.t list) (f : 'a -> 'b) (x: 'a) : 'b =
-  vis#enter_scope ls;
-  let result = f x in
-  vis#leave_scope ls;
-  result
 
 let rec locals_of_declitem (x : decl_item) : Ident.t list =
   match x with

--- a/tests/lit/dependencies/nocheck_00.isa
+++ b/tests/lit/dependencies/nocheck_00.isa
@@ -1,0 +1,9 @@
+// RUN: %iii --batchmode --exec=":dependencies %t.json" %s
+// RUN: not grep temporary_variable %t.json
+
+// Copyright (C) 2026-2026 Intel Corporation
+
+function FUT1(i : {0..15}) -> {1..256}
+begin
+    return __let temporary_variable : {1..16} := i+1 __in temporary_variable * temporary_variable;
+end


### PR DESCRIPTION
The handling of '__let x = e1 __in e2' (which, like in OCaml lets you
assign to a temporary variable in the middle of an expression), was not
handling the fact that the scope of the variable 'x' is just 'e2'.

In particular, the :metadata command was sometimes listing these
variables as global  variables that are assigned to by a function instead of
ignoring them (because they are local variables).