### PR TITLE
Github workflow: fix ocamlc version (5.4.1)

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup OCaml
         uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: 5
+          ocaml-compiler: 5.4.1
           opam-disable-sandboxing: true
           dune-cache: true
         env:


### PR DESCRIPTION
This is necessary to make the github workflow match the isa-tools.opam.locked file.