### PR TITLE
Fix tests to use Bits::Signed for 128-bit extremes

### DIFF
--- a/tests/backends/info_00.isa
+++ b/tests/backends/info_00.isa
@@ -33,15 +33,15 @@ begin
 
     // Some runtimes optimize the handling of 64-bit values
     // so test the extreme values and near neighbors.
-    let max_64 := Std::Bits::Unsigned(0x7fff_ffff_ffff_ffff);
-    let min_64 := -Std::Bits::Unsigned(0x8000_0000_0000_0000);
+    let max_64 := Std::Bits::Signed(0x7fff_ffff_ffff_ffff);
+    let min_64 := Std::Bits::Signed(0x8000_0000_0000_0000);
     Std::Info(1, "{max_64}");
     // CHECK:  {{^9223372036854775807$}}
     Std::Info(1, "{min_64}");
     // CHECK: {{^-9223372036854775808$}}
 
-    let max_64m1 :=  Std::Bits::Unsigned(0x7fff_ffff_ffff_fffe);
-    let min_64p1 := -Std::Bits::Unsigned(0x7fff_ffff_ffff_ffff);
+    let max_64m1 := Std::Bits::Signed(0x7fff_ffff_ffff_fffe);
+    let min_64p1 := Std::Bits::Signed(0x8000_0000_0000_0001);
     Std::Info(1, "{max_64m1}");
     // CHECK:  {{^9223372036854775806$}}
     Std::Info(1, "{min_64p1}");
@@ -49,8 +49,8 @@ begin
 
     // Most runtimes use 128 bits as the default int sizes
     // so test the extreme values and near neighbors.
-    let max_128 :=  Std::Bits::Unsigned(0x7fff_ffff_ffff_ffff_ffff_ffff_ffff_ffff);
-    let min_128 := -Std::Bits::Unsigned(0x8000_0000_0000_0000_0000_0000_0000_0000);
+    let max_128 := Std::Bits::Signed(0x7fff_ffff_ffff_ffff_ffff_ffff_ffff_ffff);
+    let min_128 := Std::Bits::Signed(0x8000_0000_0000_0000_0000_0000_0000_0000);
     Std::Info(1, "{max_128}");
     // CHECK-c23:          {{^0x7fffffffffffffffffffffffffffffff$}}
     // CHECK-fallback:     {{^0x7fffffffffffffffffffffffffffffff$}}
@@ -60,8 +60,8 @@ begin
     // CHECK-fallback:    {{^-0x80000000000000000000000000000000$}}
     // CHECK-interpreter: {{^-170141183460469231731687303715884105728$}}
 
-    let max_128m1 :=  Std::Bits::Unsigned(0x7fff_ffff_ffff_ffff_ffff_ffff_ffff_fffe);
-    let min_128p1 := -Std::Bits::Unsigned(0x7fff_ffff_ffff_ffff_ffff_ffff_ffff_ffff);
+    let max_128m1 := Std::Bits::Signed(0x7fff_ffff_ffff_ffff_ffff_ffff_ffff_fffe);
+    let min_128p1 := Std::Bits::Signed(0x8000_0000_0000_0000_0000_0000_0000_0001);
     Std::Info(1, "{max_128m1}");
     // CHECK-c23:          {{^0x7ffffffffffffffffffffffffffffffe$}}
     // CHECK-fallback:     {{^0x7ffffffffffffffffffffffffffffffe$}}

--- a/tests/backends/int_print_dec.isa
+++ b/tests/backends/int_print_dec.isa
@@ -8,7 +8,7 @@ begin
     Std::Print::Integer::Dec(-42); Print("\n");
     // CHECK: {{^-42$}}
 
-    let max_128 := Std::Bits::Unsigned(0x7fff_ffff_ffff_ffff_ffff_ffff_ffff_ffff);
+    let max_128 := Std::Bits::Signed(0x7fff_ffff_ffff_ffff_ffff_ffff_ffff_ffff);
     Std::Print::Integer::Dec(max_128); Print("\n");
     // CHECK-ac:          {{^0x7fffffffffffffffffffffffffffffff$}}
     // CHECK-c23:         {{^0x7fffffffffffffffffffffffffffffff$}}
@@ -16,7 +16,7 @@ begin
     // CHECK-interpreter: {{^170141183460469231731687303715884105727$}}
     // CHECK-sc:          {{^0x7fffffffffffffffffffffffffffffff$}}
 
-    let min_128 := -Std::Bits::Unsigned(0x8000_0000_0000_0000_0000_0000_0000_0000);
+    let min_128 := Std::Bits::Signed(0x8000_0000_0000_0000_0000_0000_0000_0000);
     Std::Print::Integer::Dec(min_128); Print("\n");
     // CHECK-ac:         {{^-0x80000000000000000000000000000000$}}
     // CHECK-c23:        {{^-0x80000000000000000000000000000000$}}

--- a/tests/backends/int_print_hex.isa
+++ b/tests/backends/int_print_hex.isa
@@ -10,15 +10,15 @@ begin
 
     // Some runtimes optimize the handling of 64-bit values
     // so test the extreme values and near neighbors.
-    let max_64 := Std::Bits::Unsigned(0x7fff_ffff_ffff_ffff);
-    let min_64 := -Std::Bits::Unsigned(0x8000_0000_0000_0000);
+    let max_64 := Std::Bits::Signed(0x7fff_ffff_ffff_ffff);
+    let min_64 := Std::Bits::Signed(0x8000_0000_0000_0000);
     Std::Print::Integer::Hex(max_64); Print("\n");
     // CHECK:  {{^0x7fffffffffffffff$}}
     Std::Print::Integer::Hex(min_64); Print("\n");
     // CHECK: {{^-0x8000000000000000$}}
 
-    let max_64m1 :=  Std::Bits::Unsigned(0x7fff_ffff_ffff_fffe);
-    let min_64p1 := -Std::Bits::Unsigned(0x7fff_ffff_ffff_ffff);
+    let max_64m1 := Std::Bits::Signed(0x7fff_ffff_ffff_fffe);
+    let min_64p1 := Std::Bits::Signed(0x8000_0000_0000_0001);
     Std::Print::Integer::Hex(max_64m1); Print("\n");
     // CHECK:  {{^0x7ffffffffffffffe$}}
     Std::Print::Integer::Hex(min_64p1); Print("\n");
@@ -26,15 +26,15 @@ begin
 
     // Most runtimes use 128 bits as the default int sizes
     // so test the extreme values and near neighbors.
-    let max_128 :=  Std::Bits::Unsigned(0x7fff_ffff_ffff_ffff_ffff_ffff_ffff_ffff);
-    let min_128 := -Std::Bits::Unsigned(0x8000_0000_0000_0000_0000_0000_0000_0000);
+    let max_128 := Std::Bits::Signed(0x7fff_ffff_ffff_ffff_ffff_ffff_ffff_ffff);
+    let min_128 := Std::Bits::Signed(0x8000_0000_0000_0000_0000_0000_0000_0000);
     Std::Print::Integer::Hex(max_128); Print("\n");
     // CHECK:  {{^0x7fffffffffffffffffffffffffffffff$}}
     Std::Print::Integer::Hex(min_128); Print("\n");
     // CHECK: {{^-0x80000000000000000000000000000000$}}
 
-    let max_128m1 :=  Std::Bits::Unsigned(0x7fff_ffff_ffff_ffff_ffff_ffff_ffff_fffe);
-    let min_128p1 := -Std::Bits::Unsigned(0x7fff_ffff_ffff_ffff_ffff_ffff_ffff_ffff);
+    let max_128m1 := Std::Bits::Signed(0x7fff_ffff_ffff_ffff_ffff_ffff_ffff_fffe);
+    let min_128p1 := Std::Bits::Signed(0x8000_0000_0000_0000_0000_0000_0000_0001);
     Std::Print::Integer::Hex(max_128m1); Print("\n");
     // CHECK:  {{^0x7ffffffffffffffffffffffffffffffe$}}
     Std::Print::Integer::Hex(min_128p1); Print("\n");


### PR DESCRIPTION
Literal hex numbers are treated as bitvectors, and the tests
constructed the min 128-bit integer by negating an unsigned value:

    let min_128 := -Std::Bits::Unsigned(0x8000_0000_0000_0000_0000_0000_0000_0000);

However, Bits::Unsigned(0x80...00) already gives -2\*\*127 (the minimum).
Negating it produces 2\*\*127 which overflows __int128 in the C23 backend:

    min_128 = ((__int128)(- ((__int128)((unsigned __int128)((unsigned __int128)0x80000000000000000000000000000000uwb)))));

Use Bits::Signed and drop the negation. This avoids the overflow and expresses the intended values
better.
